### PR TITLE
feat: sip.sol foundation Phase C — sip-mobile integration

### DIFF
--- a/app/send/index.tsx
+++ b/app/send/index.tsx
@@ -22,9 +22,12 @@ import {
   Keyboard,
 } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { router, useLocalSearchParams } from "expo-router"
 import * as Clipboard from "expo-clipboard"
+import type { Connection } from "@solana/web3.js"
+import { resolve as bonfidaResolve } from "@bonfida/spl-name-service"
+import bs58 from "bs58"
 import {
   ShieldCheckIcon,
   LockIcon,
@@ -33,6 +36,8 @@ import {
   AddressBookIcon,
   WarningIcon,
   CheckCircleIcon,
+  XCircleIcon,
+  SpinnerGapIcon,
   type Icon as PhosphorIcon,
 } from "phosphor-react-native"
 import { ICON_COLORS } from "@/constants/icons"
@@ -48,34 +53,27 @@ import { NumpadInput } from "@/components"
 import { Button, Modal, EmptyState } from "@/components/ui"
 import type { PrivacyLevel } from "@/types"
 import type { PrivacySendStatus } from "@/privacy-providers"
-import { SOLANA_ADDRESS_REGEX, STEALTH_ADDRESS_REGEX } from "@/utils/validation"
+import { getRpcClient } from "@/lib/rpc"
+import { getRpcApiKey } from "@/lib/config"
+import {
+  resolve as snsResolve,
+  MetaAddress,
+  NotFound,
+  Malformed,
+} from "@/lib/sns-stealth-mobile"
+import {
+  classifyInput,
+  isReadyToSend,
+  targetUri,
+  type RecipientResolution,
+} from "@/lib/recipient-resolution"
+
+// SNS resolution debounce delay (ms) — avoids firing on every keystroke
+const RESOLVE_DEBOUNCE_MS = 350
 
 // ============================================================================
 // VALIDATION HELPERS
 // ============================================================================
-
-function validateAddress(address: string): { isValid: boolean; error?: string } {
-  if (!address || address.trim() === "") {
-    return { isValid: false, error: "Address is required" }
-  }
-
-  const trimmed = address.trim()
-
-  // Check stealth address format
-  if (trimmed.startsWith("sip:")) {
-    if (STEALTH_ADDRESS_REGEX.test(trimmed)) {
-      return { isValid: true }
-    }
-    return { isValid: false, error: "Invalid stealth address format" }
-  }
-
-  // Check regular Solana address
-  if (SOLANA_ADDRESS_REGEX.test(trimmed)) {
-    return { isValid: true }
-  }
-
-  return { isValid: false, error: "Invalid Solana address" }
-}
 
 // Estimated overhead for stealth SOL transfers (tx fee + PDA rent + rent-exempt minimum)
 const STEALTH_SOL_OVERHEAD = 0.004
@@ -117,10 +115,6 @@ function validateAmount(
   return { isValid: true }
 }
 
-function isStealthAddress(address: string): boolean {
-  return address?.startsWith("sip:") && STEALTH_ADDRESS_REGEX.test(address.trim())
-}
-
 function formatUsdValue(amount: string, solPrice: number): string {
   const num = parseFloat(amount)
   if (isNaN(num) || num === 0 || solPrice === 0) return "$0.00"
@@ -149,9 +143,47 @@ export default function SendScreen() {
   } = usePrivacyProvider()
 
   const { isConnected } = useWalletStore()
-  const { defaultPrivacyLevel } = useSettingsStore()
+  const {
+    defaultPrivacyLevel,
+    network,
+    rpcProvider,
+    heliusApiKey,
+    quicknodeApiKey,
+    tritonEndpoint,
+  } = useSettingsStore()
   const { addToast } = useToastStore()
   const { balance, solPrice, tokenBalances } = useBalance()
+
+  // ── Cluster-aware Connection (Task 16 pattern).
+  //
+  // Used by the resolution effect below. Same TODO(rpc-singleton) caveat as
+  // sip-stealth.tsx: getRpcClient mutates a global singleton. Deferred to
+  // a dedicated cleanup pass — out of scope for the recipient resolution
+  // feature.
+  const connection: Connection = useMemo(() => {
+    let apiKey: string | undefined
+    let customEndpoint: string | undefined
+    switch (rpcProvider) {
+      case "helius":
+        apiKey = heliusApiKey || getRpcApiKey("helius") || undefined
+        break
+      case "quicknode":
+        apiKey = quicknodeApiKey || undefined
+        break
+      case "triton":
+        customEndpoint = tritonEndpoint || undefined
+        break
+      case "publicnode":
+      default:
+        break
+    }
+    return getRpcClient({
+      provider: rpcProvider,
+      cluster: network,
+      apiKey,
+      customEndpoint,
+    }).getConnection()
+  }, [network, rpcProvider, heliusApiKey, quicknodeApiKey, tritonEndpoint])
 
   // Token selection state
   const SOL_TOKEN: { symbol: string; name: string; mint: string; decimals: number } = {
@@ -179,8 +211,43 @@ export default function SendScreen() {
   const [txHash, setTxHash] = useState<string | null>(null)
   const [txError, setTxError] = useState<string | null>(null)
 
-  // Validation state
-  const [addressError, setAddressError] = useState<string | null>(null)
+  // Recipient resolution state machine.
+  // Drives all submit-gating + UX feedback below the input. The async ".sol"
+  // resolve runs inside the effect below; everything else is classified
+  // synchronously from `recipient` via classifyInput().
+  const [resolution, setResolution] = useState<RecipientResolution>({
+    kind: "empty",
+  })
+
+  // Deferred "View public address" preview for the not-found-record warn UX.
+  // We do NOT actually submit a transparent send to the .sol's pointer here —
+  // that's deferred work, mirroring Phase B's scope decision in sip-app.
+  const [publicAddressPreview, setPublicAddressPreview] = useState<
+    string | null
+  >(null)
+  const [publicAddressLoading, setPublicAddressLoading] = useState(false)
+
+  // ── Async resolution coordination refs ────────────────────────────────────
+  //
+  // We keep these refs INLINE (rather than extracting a RecipientInput
+  // component as sip-app's Phase B does) because:
+  //   • Phase B's reviewer flagged the unmount race as Critical C1 — we
+  //     preserve the same generation counter + unmounted guard regardless
+  //     of where the state machine lives.
+  //   • sip-mobile's send screen is monolithic by design (one tab, one
+  //     flow). Extracting RecipientInput would force a callback API
+  //     boundary, complicating RTL-less logic tests without commensurate
+  //     code-reuse benefit (no other screen needs a free-form recipient).
+  //
+  // Generation counter: every input change bumps it; awaited resolves
+  // compare against the captured generation and discard if stale.
+  const resolveGenRef = useRef(0)
+  // Debounce timer ref (350ms — matches sip-app).
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Unmount guard — flipped true in effect cleanup; checked across awaits
+  // to prevent setState on an unmounted component when a resolve settles
+  // late (Phase B Critical C1 fix).
+  const unmountedRef = useRef(false)
 
   // Reset on success + record payment for contacts
   useEffect(() => {
@@ -204,39 +271,152 @@ export default function SendScreen() {
     []
   )
 
+  // Recipient changes only update state — the resolution effect below
+  // classifies + (for .sol) async-resolves it.
   const handleRecipientChange = useCallback((value: string) => {
     setRecipient(value)
-    if (value && value.length > 10) {
-      const validation = validateAddress(value)
-      setAddressError(validation.isValid ? null : validation.error || null)
-    } else {
-      setAddressError(null)
-    }
   }, [])
 
   // Handle scanned address from QR scanner
   useEffect(() => {
     if (scannedAddress) {
       setRecipient(scannedAddress)
-      handleRecipientChange(scannedAddress)
     }
-  }, [scannedAddress, handleRecipientChange])
+  }, [scannedAddress])
 
   // Handle recipient param from contacts
   useEffect(() => {
     if (recipientParam) {
       setRecipient(recipientParam)
-      handleRecipientChange(recipientParam)
     }
-  }, [recipientParam, handleRecipientChange])
+  }, [recipientParam])
+
+  // ── Recipient resolution effect ─────────────────────────────────────────────
+  //
+  // Effect deps are `[recipient, connection]` (NOT setRecipient or its
+  // derived state) — the goal is to re-run only when the user's input
+  // string changes or the cluster-aware Connection changes (e.g. via
+  // settings). The setter functions are stable across renders by React's
+  // own contract and don't need to be in the dep list.
+  useEffect(() => {
+    // Reset the unmount flag on fresh effect runs. Cleanup (below) flips
+    // it true, but the next dep-driven run sees a new closure with this
+    // re-armed flag, which is the correct lifecycle for the in-flight
+    // awaits to detect "we've been replaced or unmounted."
+    unmountedRef.current = false
+
+    // Cancel any pending debounce from a previous keystroke.
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+
+    const initial = classifyInput(recipient)
+
+    // Non-SNS states resolve synchronously — no debounce needed.
+    if (initial.kind !== "sns-resolving") {
+      resolveGenRef.current += 1
+      setResolution(initial)
+      setPublicAddressPreview(null)
+      return
+    }
+
+    // SNS path: show resolving immediately, debounce the network call.
+    setResolution(initial)
+    setPublicAddressPreview(null)
+
+    const generation = ++resolveGenRef.current
+    const domain = initial.domain
+
+    debounceRef.current = setTimeout(async () => {
+      if (unmountedRef.current) return
+      if (!connection) return
+
+      try {
+        const result = await snsResolve(connection, domain)
+
+        if (unmountedRef.current) return
+        if (resolveGenRef.current !== generation) return // stale — discard
+
+        let next: RecipientResolution
+
+        if (result instanceof MetaAddress) {
+          // Build sip:solana:<spend>:<view> URI at the resolution boundary.
+          // The send() call's contract is the URI string, not MetaAddress.
+          const uri = `sip:solana:${bs58.encode(result.spending)}:${bs58.encode(result.viewing)}`
+          next = { kind: "sns-resolved", domain, uri }
+        } else if (result instanceof NotFound) {
+          next =
+            result.subject === "domain"
+              ? { kind: "sns-not-found-domain", domain }
+              : { kind: "sns-not-found-record", domain }
+        } else if (result instanceof Malformed) {
+          next = { kind: "sns-malformed", domain, reason: result.reason }
+        } else {
+          // Defensive: unknown variant. Map to malformed with placeholder.
+          next = { kind: "sns-malformed", domain, reason: "unknown" }
+        }
+
+        setResolution(next)
+      } catch (err) {
+        if (unmountedRef.current) return
+        if (resolveGenRef.current !== generation) return
+
+        logger.error("[Send] SNS resolution error:", err)
+        // Network/chain errors: surface as not-found-domain (safe, red error).
+        setResolution({ kind: "sns-not-found-domain", domain })
+      }
+    }, RESOLVE_DEBOUNCE_MS)
+
+    return () => {
+      unmountedRef.current = true
+      if (debounceRef.current !== null) {
+        clearTimeout(debounceRef.current)
+        debounceRef.current = null
+      }
+    }
+  }, [recipient, connection])
+
+  // ── "View public address" handler for the not-found-record warn UX ─────────
+  //
+  // Surfaces the .sol's SOL pointer (Bonfida resolve) so the user can copy
+  // it manually. We do NOT auto-submit a transparent transfer here — that's
+  // deferred work, same scope decision as Phase B in sip-app.
+  const handleViewPublicAddress = useCallback(async () => {
+    if (resolution.kind !== "sns-not-found-record") return
+    const domain = resolution.domain
+    setPublicAddressLoading(true)
+    setPublicAddressPreview(null)
+    try {
+      const pubkey = await bonfidaResolve(connection, domain)
+      setPublicAddressPreview(pubkey.toBase58())
+    } catch (err) {
+      logger.error("[Send] Bonfida resolve (View public) failed:", err)
+      setPublicAddressPreview("error")
+    } finally {
+      setPublicAddressLoading(false)
+    }
+  }, [resolution, connection])
+
+  const handleCancelDomain = useCallback(() => {
+    setRecipient("")
+  }, [])
 
   const handleReview = useCallback(() => {
     Keyboard.dismiss()
 
-    // Final validation
-    const addrValidation = validateAddress(recipient)
-    if (!addrValidation.isValid) {
-      setAddressError(addrValidation.error || "Invalid address")
+    // Final validation — submit-gate uses the same isReadyToSend predicate
+    // that the disabled-state below uses, so this branch is only reached
+    // when the state machine says we're ready. Defensive guard remains.
+    if (!isReadyToSend(resolution)) {
+      addToast({
+        type: "error",
+        title: "Recipient not ready",
+        message:
+          resolution.kind === "sns-resolving"
+            ? "Still resolving the .sol domain — try again in a moment"
+            : "Enter a valid recipient",
+      })
       return
     }
 
@@ -262,7 +442,7 @@ export default function SendScreen() {
 
     hapticMedium()
     setShowConfirmModal(true)
-  }, [recipient, amount, selectedBalance, providerReady, providerError, addToast])
+  }, [resolution, amount, selectedBalance, providerReady, providerError, addToast])
 
   const handleConfirmSend = useCallback(async () => {
     logger.debug("[Send] Starting transaction...")
@@ -271,12 +451,18 @@ export default function SendScreen() {
     setTxError(null)
     setTxHash(null)
 
+    // Use the resolved sip: URI for sns-resolved kinds so the underlying
+    // send() call receives a canonical sip:solana:<spend>:<view> string
+    // (it already understands that shape). For sip-uri / solana-address
+    // kinds, targetUri() returns the raw input verbatim.
+    const sendTarget = targetUri(resolution) ?? recipient
+
     try {
       // Execute send via Privacy Provider
       const result = await send(
         {
           amount,
-          recipient,
+          recipient: sendTarget,
           privacyLevel: defaultPrivacyLevel,
           tokenMint: isSOL ? undefined : selectedToken.mint,
         },
@@ -311,7 +497,16 @@ export default function SendScreen() {
         message: errorMessage,
       })
     }
-  }, [send, amount, recipient, defaultPrivacyLevel, isSOL, selectedToken.mint, addToast])
+  }, [
+    send,
+    amount,
+    recipient,
+    resolution,
+    defaultPrivacyLevel,
+    isSOL,
+    selectedToken.mint,
+    addToast,
+  ])
 
   const handleCloseSuccess = useCallback(() => {
     setShowSuccessModal(false)
@@ -363,7 +558,10 @@ export default function SendScreen() {
     }
   }
 
-  const isStealth = recipient && isStealthAddress(recipient)
+  // Stealth iff the resolved recipient is a sip: URI (raw or .sol-derived).
+  // `solana-address` kind is explicitly NOT stealth.
+  const isStealth =
+    resolution.kind === "sip-uri" || resolution.kind === "sns-resolved"
 
   if (!isConnected) {
     return (
@@ -381,7 +579,9 @@ export default function SendScreen() {
     )
   }
 
-  const isValidRecipient = !!recipient && !addressError
+  // Submit gate: ready iff the resolution is in a sendable state. .sol
+  // resolutions in flight return false so the CTA stays disabled.
+  const isValidRecipient = isReadyToSend(resolution)
   const ctaLabel = providerInitializing
     ? "Initializing..."
     : defaultPrivacyLevel !== "transparent"
@@ -435,13 +635,19 @@ export default function SendScreen() {
             </View>
             <View
               className={`bg-dark-900 rounded-xl border p-4 ${
-                addressError ? "border-red-500" : "border-dark-800"
+                resolution.kind === "sns-resolved" || resolution.kind === "sip-uri"
+                  ? "border-green-500/60"
+                  : resolution.kind === "sns-not-found-domain" ||
+                    resolution.kind === "sns-malformed" ||
+                    resolution.kind === "invalid"
+                  ? "border-red-500"
+                  : "border-dark-800"
               }`}
             >
               <TextInput
                 testID="recipient-input"
                 className="text-white"
-                placeholder="Wallet address or sip: stealth address"
+                placeholder="alice.sol, sip:solana:…, or a Solana address"
                 placeholderTextColor="#71717a"
                 value={recipient}
                 onChangeText={handleRecipientChange}
@@ -451,8 +657,189 @@ export default function SendScreen() {
                 numberOfLines={2}
               />
             </View>
-            {addressError && (
-              <Text className="text-red-400 text-sm mt-2">{addressError}</Text>
+
+            {/* Resolution feedback (replaces the old single-line addressError) */}
+            {resolution.kind === "sns-resolving" && (
+              <View
+                testID="recipient-resolving"
+                className="flex-row items-center mt-2"
+              >
+                <SpinnerGapIcon
+                  size={14}
+                  color={ICON_COLORS.muted}
+                  weight="regular"
+                />
+                <Text className="text-dark-400 text-sm ml-2">
+                  Resolving {resolution.domain}…
+                </Text>
+              </View>
+            )}
+
+            {resolution.kind === "sns-resolved" && (
+              <View
+                testID="recipient-resolved"
+                className="flex-row items-center mt-2"
+              >
+                <CheckCircleIcon
+                  size={14}
+                  color={ICON_COLORS.success}
+                  weight="fill"
+                />
+                <Text className="text-green-400 text-sm ml-2">
+                  {resolution.domain} · private payment available
+                </Text>
+              </View>
+            )}
+
+            {resolution.kind === "sip-uri" && (
+              <View
+                testID="recipient-sip-uri"
+                className="flex-row items-center mt-2"
+              >
+                <CheckCircleIcon
+                  size={14}
+                  color={ICON_COLORS.success}
+                  weight="fill"
+                />
+                <Text className="text-green-400 text-sm ml-2">
+                  SIP stealth address ready
+                </Text>
+              </View>
+            )}
+
+            {resolution.kind === "sns-not-found-record" && (
+              <View
+                testID="recipient-not-found-record"
+                className="mt-3 bg-yellow-900/20 border border-yellow-700/50 rounded-xl p-3"
+              >
+                <View className="flex-row items-start gap-2">
+                  <WarningIcon
+                    size={18}
+                    color={ICON_COLORS.warning}
+                    weight="fill"
+                  />
+                  <View className="flex-1">
+                    <Text className="text-yellow-300 font-semibold text-sm">
+                      Private payment not available
+                    </Text>
+                    <Text className="text-yellow-400/80 text-xs mt-0.5">
+                      {resolution.domain} hasn&apos;t enabled SIP-STEALTH.
+                    </Text>
+                  </View>
+                </View>
+
+                {publicAddressLoading && (
+                  <View className="flex-row items-center mt-3">
+                    <SpinnerGapIcon
+                      size={12}
+                      color={ICON_COLORS.muted}
+                      weight="regular"
+                    />
+                    <Text className="text-dark-400 text-xs ml-2">
+                      Looking up public address…
+                    </Text>
+                  </View>
+                )}
+
+                {publicAddressPreview &&
+                  publicAddressPreview !== "error" && (
+                    <View className="mt-3">
+                      <Text className="text-dark-400 text-xs">
+                        Public address:
+                      </Text>
+                      <Text className="text-white font-mono text-xs mt-1">
+                        {publicAddressPreview}
+                      </Text>
+                      <Text className="text-dark-500 text-xs mt-2">
+                        Public sends via .sol are coming in a follow-up — not
+                        yet available.
+                      </Text>
+                    </View>
+                  )}
+
+                {publicAddressPreview === "error" && (
+                  <Text className="text-red-400 text-xs mt-3">
+                    Could not look up public address for {resolution.domain}.
+                  </Text>
+                )}
+
+                <View className="flex-row gap-2 mt-3">
+                  <TouchableOpacity
+                    onPress={handleViewPublicAddress}
+                    disabled={publicAddressLoading}
+                    className={`rounded-lg px-3 py-2 ${
+                      publicAddressLoading
+                        ? "bg-yellow-800/30"
+                        : "bg-yellow-700/40"
+                    }`}
+                    accessibilityRole="button"
+                    accessibilityLabel="View public address"
+                  >
+                    <Text className="text-yellow-200 text-xs font-semibold">
+                      View public address
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={handleCancelDomain}
+                    className="rounded-lg px-3 py-2 border border-dark-700"
+                    accessibilityRole="button"
+                    accessibilityLabel="Cancel domain resolution"
+                  >
+                    <Text className="text-dark-300 text-xs font-semibold">
+                      Cancel
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
+
+            {resolution.kind === "sns-not-found-domain" && (
+              <View
+                testID="recipient-not-found-domain"
+                className="flex-row items-center mt-2"
+              >
+                <XCircleIcon
+                  size={14}
+                  color={ICON_COLORS.error}
+                  weight="fill"
+                />
+                <Text className="text-red-400 text-sm ml-2">
+                  {resolution.domain} not found
+                </Text>
+              </View>
+            )}
+
+            {resolution.kind === "sns-malformed" && (
+              <View
+                testID="recipient-malformed"
+                className="flex-row items-center mt-2"
+              >
+                <XCircleIcon
+                  size={14}
+                  color={ICON_COLORS.error}
+                  weight="fill"
+                />
+                <Text className="text-red-400 text-sm ml-2">
+                  {resolution.domain}&apos;s privacy record is invalid (
+                  {resolution.reason})
+                </Text>
+              </View>
+            )}
+
+            {resolution.kind === "invalid" && (
+              <View
+                testID="recipient-invalid"
+                className="flex-row items-center mt-2"
+              >
+                <XCircleIcon
+                  size={14}
+                  color={ICON_COLORS.error}
+                  weight="fill"
+                />
+                <Text className="text-red-400 text-sm ml-2">
+                  Invalid format. Use a .sol domain, sip:solana:&lt;spend&gt;:&lt;view&gt;, or a Solana address
+                </Text>
+              </View>
             )}
 
             {/* Quick Actions */}
@@ -588,18 +975,16 @@ export default function SendScreen() {
             </View>
           )}
 
-          {/* Warning for non-stealth address with private transfer */}
-          {recipient &&
-            !isStealth &&
-            defaultPrivacyLevel !== "transparent" &&
-            !addressError && (
+          {/* Warning for transparent (base58) recipient with private-default */}
+          {resolution.kind === "solana-address" &&
+            defaultPrivacyLevel !== "transparent" && (
               <View className="mt-3 bg-yellow-900/20 border border-yellow-700/50 rounded-xl p-3">
                 <View className="flex-row items-start gap-2">
                   <WarningIcon size={20} color={ICON_COLORS.warning} weight="fill" />
                   <Text className="text-yellow-400 text-sm flex-1">
                     For full privacy, ask the recipient for their stealth address
-                    (sip:...). Regular addresses can still receive private transfers
-                    but with reduced privacy.
+                    (sip:...) or use their .sol domain. Regular addresses can
+                    still receive private transfers but with reduced privacy.
                   </Text>
                 </View>
               </View>

--- a/app/send/index.tsx
+++ b/app/send/index.tsx
@@ -222,10 +222,20 @@ export default function SendScreen() {
   // Deferred "View public address" preview for the not-found-record warn UX.
   // We do NOT actually submit a transparent send to the .sol's pointer here —
   // that's deferred work, mirroring Phase B's scope decision in sip-app.
-  const [publicAddressPreview, setPublicAddressPreview] = useState<
-    string | null
-  >(null)
-  const [publicAddressLoading, setPublicAddressLoading] = useState(false)
+  //
+  // Discriminated union (m2 carry-forward from Phase B): the previous shape
+  // was `publicAddressPreview: string | null` with `"error"` as a magic-string
+  // sentinel plus a separate `publicAddressLoading: boolean`. The handoff
+  // doc explicitly called this out as cleanup-in-Phase-C work, so we
+  // consolidate the two slots into a single tagged-union slot with
+  // exhaustive kind-checks at the render sites.
+  type PublicAddressState =
+    | { kind: "idle" }
+    | { kind: "loading" }
+    | { kind: "ready"; address: string }
+    | { kind: "error" }
+  const [publicAddressState, setPublicAddressState] =
+    useState<PublicAddressState>({ kind: "idle" })
 
   // ── Async resolution coordination refs ────────────────────────────────────
   //
@@ -317,13 +327,13 @@ export default function SendScreen() {
     if (initial.kind !== "sns-resolving") {
       resolveGenRef.current += 1
       setResolution(initial)
-      setPublicAddressPreview(null)
+      setPublicAddressState({ kind: "idle" })
       return
     }
 
     // SNS path: show resolving immediately, debounce the network call.
     setResolution(initial)
-    setPublicAddressPreview(null)
+    setPublicAddressState({ kind: "idle" })
 
     const generation = ++resolveGenRef.current
     const domain = initial.domain
@@ -382,19 +392,28 @@ export default function SendScreen() {
   // Surfaces the .sol's SOL pointer (Bonfida resolve) so the user can copy
   // it manually. We do NOT auto-submit a transparent transfer here — that's
   // deferred work, same scope decision as Phase B in sip-app.
+  //
+  // Race-safety (I1): we capture the current resolveGenRef generation at
+  // entry and re-check it (plus `unmountedRef`) before every setState. If
+  // the user types a different domain (or clears the input, or navigates
+  // away) while Bonfida is in flight, the late resolution is discarded
+  // instead of overwriting state that now belongs to a different domain.
+  // The SNS resolution effect bumps resolveGenRef on every input change
+  // (see lines 318 / 328), so a fresh keystroke naturally invalidates any
+  // pending Bonfida lookup spawned by this handler.
   const handleViewPublicAddress = useCallback(async () => {
     if (resolution.kind !== "sns-not-found-record") return
+    const gen = resolveGenRef.current
     const domain = resolution.domain
-    setPublicAddressLoading(true)
-    setPublicAddressPreview(null)
+    setPublicAddressState({ kind: "loading" })
     try {
       const pubkey = await bonfidaResolve(connection, domain)
-      setPublicAddressPreview(pubkey.toBase58())
+      if (resolveGenRef.current !== gen || unmountedRef.current) return
+      setPublicAddressState({ kind: "ready", address: pubkey.toBase58() })
     } catch (err) {
+      if (resolveGenRef.current !== gen || unmountedRef.current) return
       logger.error("[Send] Bonfida resolve (View public) failed:", err)
-      setPublicAddressPreview("error")
-    } finally {
-      setPublicAddressLoading(false)
+      setPublicAddressState({ kind: "error" })
     }
   }, [resolution, connection])
 
@@ -442,7 +461,15 @@ export default function SendScreen() {
 
     hapticMedium()
     setShowConfirmModal(true)
-  }, [resolution, amount, selectedBalance, providerReady, providerError, addToast])
+  }, [
+    resolution,
+    amount,
+    selectedBalance,
+    isSOL,
+    providerReady,
+    providerError,
+    addToast,
+  ])
 
   const handleConfirmSend = useCallback(async () => {
     logger.debug("[Send] Starting transaction...")
@@ -728,7 +755,7 @@ export default function SendScreen() {
                   </View>
                 </View>
 
-                {publicAddressLoading && (
+                {publicAddressState.kind === "loading" && (
                   <View className="flex-row items-center mt-3">
                     <SpinnerGapIcon
                       size={12}
@@ -741,23 +768,22 @@ export default function SendScreen() {
                   </View>
                 )}
 
-                {publicAddressPreview &&
-                  publicAddressPreview !== "error" && (
-                    <View className="mt-3">
-                      <Text className="text-dark-400 text-xs">
-                        Public address:
-                      </Text>
-                      <Text className="text-white font-mono text-xs mt-1">
-                        {publicAddressPreview}
-                      </Text>
-                      <Text className="text-dark-500 text-xs mt-2">
-                        Public sends via .sol are coming in a follow-up — not
-                        yet available.
-                      </Text>
-                    </View>
-                  )}
+                {publicAddressState.kind === "ready" && (
+                  <View className="mt-3">
+                    <Text className="text-dark-400 text-xs">
+                      Public address:
+                    </Text>
+                    <Text className="text-white font-mono text-xs mt-1">
+                      {publicAddressState.address}
+                    </Text>
+                    <Text className="text-dark-500 text-xs mt-2">
+                      Public sends via .sol are coming in a follow-up — not
+                      yet available.
+                    </Text>
+                  </View>
+                )}
 
-                {publicAddressPreview === "error" && (
+                {publicAddressState.kind === "error" && (
                   <Text className="text-red-400 text-xs mt-3">
                     Could not look up public address for {resolution.domain}.
                   </Text>
@@ -766,9 +792,9 @@ export default function SendScreen() {
                 <View className="flex-row gap-2 mt-3">
                   <TouchableOpacity
                     onPress={handleViewPublicAddress}
-                    disabled={publicAddressLoading}
+                    disabled={publicAddressState.kind === "loading"}
                     className={`rounded-lg px-3 py-2 ${
-                      publicAddressLoading
+                      publicAddressState.kind === "loading"
                         ? "bg-yellow-800/30"
                         : "bg-yellow-700/40"
                     }`}

--- a/app/settings/_layout.tsx
+++ b/app/settings/_layout.tsx
@@ -19,6 +19,7 @@ export default function SettingsLayout() {
         <Stack.Screen name="compliance" />
         <Stack.Screen name="privacy-score" />
         <Stack.Screen name="stealth-backup" />
+        <Stack.Screen name="sip-stealth" />
       </Stack>
     </View>
   )

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -245,6 +245,13 @@ export default function SettingsScreen() {
               subtitle="Export or restore your stealth key archive"
               onPress={() => router.push("/settings/stealth-backup" as any)}
             />
+            <NavRow
+              Icon={GlobeIcon}
+              iconColor={ICON_COLORS.brand}
+              title="Private Payments by Name"
+              subtitle="Publish SIP-STEALTH on your .sol domains"
+              onPress={() => router.push("/settings/sip-stealth" as any)}
+            />
           </View>
 
           {/* Display */}

--- a/app/settings/sip-stealth.tsx
+++ b/app/settings/sip-stealth.tsx
@@ -21,8 +21,8 @@ import {
 } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { router } from "expo-router"
-import { useState, useEffect, useCallback, useMemo } from "react"
-import type { Connection } from "@solana/web3.js"
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import type { Connection, Transaction } from "@solana/web3.js"
 import { getAllDomains, reverseLookup } from "@bonfida/spl-name-service"
 import {
   ArrowLeftIcon,
@@ -82,6 +82,14 @@ export default function SipStealthScreen() {
 
   // ── Cluster-aware Connection (per the brief: callers provide it; do NOT
   //    instantiate inside the screen with hardcoded RPC env).
+  //
+  // TODO(rpc-singleton): `getRpcClient(config)` despite its "Get or create"
+  // docstring (src/lib/rpc.ts:229-239) mutates a global singleton on every
+  // call that passes a config. Six call-sites in this app now share that
+  // singleton, so a config change in one screen silently re-points every
+  // other screen's Connection. The right shape is `createRpcClient(config)`
+  // returning a fresh instance per caller. Deferred to a dedicated cleanup
+  // pass — refactoring rpc.ts is out of scope for this screen.
   const connection: Connection = useMemo(() => {
     let apiKey: string | undefined
     let customEndpoint: string | undefined
@@ -115,6 +123,30 @@ export default function SipStealthScreen() {
 
   const [loadState, setLoadState] = useState<LoadState>({ kind: "idle" })
   const [cards, setCards] = useState<Record<string, CardData>>({})
+  // Bumping this triggers a re-run of the load effect — used by the
+  // "Try again" CTA on load failure (I3) and by post-publish settling
+  // when settings changed mid-publish (C2).
+  const [reloadToken, setReloadToken] = useState(0)
+
+  // ── Publish-in-flight invariant (C2).
+  //
+  // The load effect's dep list includes `connection`, which is derived from
+  // network/RPC settings. If the user changes settings mid-publish, the
+  // effect would otherwise tear down state (`setCards({})`) and re-fire for
+  // the new cluster while the original publish is still resolving against
+  // the OLD `connection`. When that publish finally settles, its
+  // `setCards(prev => ...)` would write into state that's already been
+  // re-initialised for the new cluster — surfacing a phantom card.
+  //
+  // Invariant: while at least one publish is in flight, the load effect
+  // becomes a no-op (no state wipe, no reload). After the last publish
+  // settles, if a settings change was observed mid-flight, we bump
+  // `reloadToken` to force a clean reload. Settings are effectively
+  // read-only from the screen's perspective during publish — the on-chain
+  // TX itself runs on the cluster the user clicked from, which is the
+  // expected behavior.
+  const publishingCountRef = useRef(0)
+  const pendingReloadRef = useRef(false)
 
   const walletReady = isWalletReady({
     wallet: native.wallet,
@@ -125,6 +157,16 @@ export default function SipStealthScreen() {
   // ── Load .sol domains owned by the wallet + classify each.
   useEffect(() => {
     let cancelled = false
+
+    // C2: while a publish is in flight, settings changes must not wipe
+    // state or reload. Defer the reload — handlePublish will bump
+    // reloadToken when the last publish settles.
+    if (publishingCountRef.current > 0) {
+      pendingReloadRef.current = true
+      return () => {
+        cancelled = true
+      }
+    }
 
     if (!walletReady || !native.wallet) {
       setLoadState({ kind: "idle" })
@@ -219,7 +261,7 @@ export default function SipStealthScreen() {
     return () => {
       cancelled = true
     }
-  }, [walletReady, native.wallet, connection])
+  }, [walletReady, native.wallet, connection, reloadToken])
 
   const handlePublish = useCallback(
     async (entry: DomainEntry) => {
@@ -239,11 +281,30 @@ export default function SipStealthScreen() {
         },
       }))
 
+      // C2: mark publish as in-flight so the load effect won't wipe state
+      // if settings change mid-publish.
+      publishingCountRef.current += 1
+
       try {
         const publishWallet: PublishWallet = {
           publicKey: native.wallet.publicKey,
           signMessage: native.signMessage,
-          signTransaction: native.signTransaction as PublishWallet["signTransaction"],
+          // I2: wrap rather than cast away the entire field. The
+          // implementation in useNativeWallet (src/hooks/useNativeWallet.ts:402)
+          // is generic — `<T extends Transaction | VersionedTransaction>(tx: T) => Promise<T>` —
+          // and returns the exact instance it was passed (it mutates via
+          // `tx.partialSign(keypair)` and returns `tx`). But `useCallback`
+          // erases the generic at the hook's interface boundary
+          // (UseNativeWalletReturn.signTransaction:
+          //   `(tx: Transaction | VersionedTransaction) => Promise<Transaction | VersionedTransaction>`).
+          // `buildPublishTx` only ever emits a legacy `Transaction` (never
+          // `VersionedTransaction`), so the narrow cast on the return is
+          // sound. The wrapper localizes the cast to a single typed lambda
+          // — far safer than the previous full-callback cast through
+          // `PublishWallet["signTransaction"]`, which would have hidden a
+          // signature mismatch anywhere in the field shape.
+          signTransaction: (tx: Transaction) =>
+            native.signTransaction(tx) as Promise<Transaction>,
         }
         const { signature } = await publish(
           connection,
@@ -270,10 +331,26 @@ export default function SipStealthScreen() {
             errorMessage: errorMessageFor(err),
           },
         }))
+      } finally {
+        // C2: decrement and flush deferred reload when the last publish
+        // settles. If settings changed while at least one publish was in
+        // flight, pendingReloadRef will be true and we bump reloadToken
+        // to force the effect to re-run cleanly.
+        publishingCountRef.current -= 1
+        if (publishingCountRef.current === 0 && pendingReloadRef.current) {
+          pendingReloadRef.current = false
+          setReloadToken((t) => t + 1)
+        }
       }
     },
     [connection, native.wallet, native.signMessage, native.signTransaction]
   )
+
+  // I3: "Try again" trigger for the load-error state. Reuses the same
+  // reloadToken plumbing as C2's deferred reload.
+  const handleRetryLoad = useCallback(() => {
+    setReloadToken((t) => t + 1)
+  }, [])
 
   // ────────────────────────────────────────────────────────────────────────
   // RENDER
@@ -374,9 +451,19 @@ export default function SipStealthScreen() {
                   Failed to load domains
                 </Text>
               </View>
-              <Text className="text-dark-400 text-sm">
+              <Text className="text-dark-400 text-sm mb-3">
                 {loadState.message}
               </Text>
+              <TouchableOpacity
+                onPress={handleRetryLoad}
+                className="bg-brand-600 rounded-xl px-4 py-2 self-start"
+                accessibilityRole="button"
+                accessibilityLabel="Try loading domains again"
+              >
+                <Text className="text-white font-semibold text-sm">
+                  Try again
+                </Text>
+              </TouchableOpacity>
             </View>
           )}
 

--- a/app/settings/sip-stealth.tsx
+++ b/app/settings/sip-stealth.tsx
@@ -1,0 +1,657 @@
+/**
+ * SIP-STEALTH Publish Screen
+ *
+ * Lists all .sol domains owned by the connected wallet, shows the SIP-STEALTH
+ * state of each, and offers an "Enable" CTA per-domain.
+ *
+ * The Connection is derived from useSettingsStore so the screen reacts to
+ * cluster + RPC provider changes (cluster-aware everything, per Phase B).
+ *
+ * Pure helpers exported below the component are tested directly in
+ * tests/screens/sipStealth.test.ts (the repo's convention is logic-level
+ * tests, not RTL).
+ */
+
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  Linking,
+} from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { router } from "expo-router"
+import { useState, useEffect, useCallback, useMemo } from "react"
+import type { Connection } from "@solana/web3.js"
+import { getAllDomains, reverseLookup } from "@bonfida/spl-name-service"
+import {
+  ArrowLeftIcon,
+  GlobeIcon,
+  CheckCircleIcon,
+  WarningIcon,
+  ArrowSquareOutIcon,
+  ShieldCheckIcon,
+} from "phosphor-react-native"
+import { ICON_COLORS } from "@/constants/icons"
+import { useNativeWallet } from "@/hooks"
+import { useSettingsStore } from "@/stores/settings"
+import { getRpcClient } from "@/lib/rpc"
+import { getRpcApiKey } from "@/lib/config"
+import { getExplorerTxUrl, getExplorerName } from "@/utils/explorer"
+import { logger } from "@/utils/logger"
+import {
+  classifyResolveResult,
+  errorMessageFor,
+  isWalletReady,
+  loadErrorMessageFor,
+  type CardData,
+  type CardState,
+} from "@/utils/sipStealthHelpers"
+import {
+  resolve,
+  publish,
+  type PublishWallet,
+} from "@/lib/sns-stealth-mobile"
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+interface DomainEntry {
+  pubkey: string
+  bareName: string
+  fullDomain: string
+}
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; domains: DomainEntry[] }
+  | { kind: "error"; message: string }
+
+export default function SipStealthScreen() {
+  const native = useNativeWallet()
+  const {
+    network,
+    rpcProvider,
+    heliusApiKey,
+    quicknodeApiKey,
+    tritonEndpoint,
+    defaultExplorer,
+  } = useSettingsStore()
+
+  // ── Cluster-aware Connection (per the brief: callers provide it; do NOT
+  //    instantiate inside the screen with hardcoded RPC env).
+  const connection: Connection = useMemo(() => {
+    let apiKey: string | undefined
+    let customEndpoint: string | undefined
+    switch (rpcProvider) {
+      case "helius":
+        apiKey = heliusApiKey || getRpcApiKey("helius") || undefined
+        break
+      case "quicknode":
+        apiKey = quicknodeApiKey || undefined
+        break
+      case "triton":
+        customEndpoint = tritonEndpoint || undefined
+        break
+      case "publicnode":
+      default:
+        break
+    }
+    return getRpcClient({
+      provider: rpcProvider,
+      cluster: network,
+      apiKey,
+      customEndpoint,
+    }).getConnection()
+  }, [
+    network,
+    rpcProvider,
+    heliusApiKey,
+    quicknodeApiKey,
+    tritonEndpoint,
+  ])
+
+  const [loadState, setLoadState] = useState<LoadState>({ kind: "idle" })
+  const [cards, setCards] = useState<Record<string, CardData>>({})
+
+  const walletReady = isWalletReady({
+    wallet: native.wallet,
+    isInitialized: native.isInitialized,
+    isLoading: native.isLoading,
+  })
+
+  // ── Load .sol domains owned by the wallet + classify each.
+  useEffect(() => {
+    let cancelled = false
+
+    if (!walletReady || !native.wallet) {
+      setLoadState({ kind: "idle" })
+      setCards({})
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setLoadState({ kind: "loading" })
+    setCards({})
+
+    async function load() {
+      if (!native.wallet) return
+      try {
+        const records = await getAllDomains(connection, native.wallet.publicKey)
+        if (cancelled) return
+
+        if (records.length === 0) {
+          setLoadState({ kind: "loaded", domains: [] })
+          return
+        }
+
+        const entries = await Promise.all(
+          records.map(async (record) => {
+            const bareName = await reverseLookup(connection, record)
+            return {
+              pubkey: record.toBase58(),
+              bareName,
+              fullDomain: `${bareName}.sol`,
+            }
+          })
+        )
+        if (cancelled) return
+
+        // Seed each card into `loading` before kicking off resolves.
+        const initialCards: Record<string, CardData> = {}
+        for (const e of entries) {
+          initialCards[e.pubkey] = {
+            state: "loading",
+            domainName: e.fullDomain,
+            signature: null,
+            errorMessage: null,
+          }
+        }
+        setCards(initialCards)
+        setLoadState({ kind: "loaded", domains: entries })
+
+        // Classify each in parallel; commit all results in one final setState
+        // after a cancellation check (safer than per-card updates which can
+        // race against unmount).
+        const results = await Promise.all(
+          entries.map(async (e) => {
+            try {
+              const r = await resolve(connection, e.fullDomain)
+              const next: CardState = classifyResolveResult(r)
+              return [e.pubkey, {
+                state: next,
+                domainName: e.fullDomain,
+                signature: null,
+                errorMessage: null,
+              } satisfies CardData] as const
+            } catch (err) {
+              logger.error("[sip-stealth] resolve failed", err)
+              return [e.pubkey, {
+                state: "error" as CardState,
+                domainName: e.fullDomain,
+                signature: null,
+                errorMessage: loadErrorMessageFor(err),
+              } satisfies CardData] as const
+            }
+          })
+        )
+        if (cancelled) return
+
+        const final: Record<string, CardData> = {}
+        for (const [pk, data] of results) {
+          final[pk] = data
+        }
+        setCards(final)
+      } catch (err) {
+        if (cancelled) return
+        logger.error("[sip-stealth] getAllDomains failed", err)
+        setLoadState({
+          kind: "error",
+          message: loadErrorMessageFor(err),
+        })
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [walletReady, native.wallet, connection])
+
+  const handlePublish = useCallback(
+    async (entry: DomainEntry) => {
+      if (!native.wallet) return
+
+      setCards((prev) => ({
+        ...prev,
+        [entry.pubkey]: {
+          ...(prev[entry.pubkey] ?? {
+            state: "no-record",
+            domainName: entry.fullDomain,
+            signature: null,
+            errorMessage: null,
+          }),
+          state: "publishing",
+          errorMessage: null,
+        },
+      }))
+
+      try {
+        const publishWallet: PublishWallet = {
+          publicKey: native.wallet.publicKey,
+          signMessage: native.signMessage,
+          signTransaction: native.signTransaction as PublishWallet["signTransaction"],
+        }
+        const { signature } = await publish(
+          connection,
+          entry.fullDomain,
+          publishWallet
+        )
+        setCards((prev) => ({
+          ...prev,
+          [entry.pubkey]: {
+            state: "published",
+            domainName: entry.fullDomain,
+            signature,
+            errorMessage: null,
+          },
+        }))
+      } catch (err) {
+        logger.error("[sip-stealth] publish failed", err)
+        setCards((prev) => ({
+          ...prev,
+          [entry.pubkey]: {
+            state: "no-record",
+            domainName: entry.fullDomain,
+            signature: null,
+            errorMessage: errorMessageFor(err),
+          },
+        }))
+      }
+    },
+    [connection, native.wallet, native.signMessage, native.signTransaction]
+  )
+
+  // ────────────────────────────────────────────────────────────────────────
+  // RENDER
+  // ────────────────────────────────────────────────────────────────────────
+
+  return (
+    <SafeAreaView className="flex-1 bg-dark-950">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-6 py-4 border-b border-dark-900">
+        <TouchableOpacity
+          className="flex-row items-center"
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <ArrowLeftIcon size={24} color={ICON_COLORS.white} weight="bold" />
+          <Text className="text-white ml-4 text-lg">Back</Text>
+        </TouchableOpacity>
+        <Text className="text-xl font-bold text-white">SIP-STEALTH</Text>
+        <View className="w-16" />
+      </View>
+
+      <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+        <View className="px-6 pt-6 pb-8">
+          {/* Intro */}
+          <View className="mb-6">
+            <View className="flex-row items-center mb-2">
+              <View className="w-10 h-10 rounded-xl bg-brand-900/30 items-center justify-center">
+                <ShieldCheckIcon
+                  size={20}
+                  color={ICON_COLORS.brand}
+                  weight="fill"
+                />
+              </View>
+              <Text className="text-white text-xl font-bold ml-3">
+                Enable Private Payments
+              </Text>
+            </View>
+            <Text className="text-dark-400 text-sm leading-5">
+              Publish a SIP-STEALTH record to your{" "}
+              <Text className="text-white font-medium">.sol</Text> domain so
+              others can send you private payments without revealing your
+              wallet address on-chain.
+            </Text>
+          </View>
+
+          {/* Wallet not connected */}
+          {!walletReady && (
+            <View className="bg-dark-900 rounded-xl border border-dark-800 p-6 items-center">
+              <View className="w-14 h-14 rounded-full bg-dark-800 items-center justify-center mb-3">
+                <ShieldCheckIcon
+                  size={24}
+                  color={ICON_COLORS.muted}
+                  weight="regular"
+                />
+              </View>
+              <Text className="text-white font-medium text-base mb-1">
+                Connect wallet first
+              </Text>
+              <Text className="text-dark-500 text-sm text-center">
+                Set up or import a wallet to see your .sol domains and enable
+                private payments.
+              </Text>
+            </View>
+          )}
+
+          {/* Loading skeleton */}
+          {walletReady && loadState.kind === "loading" && (
+            <View>
+              {[0, 1, 2].map((i) => (
+                <View
+                  key={i}
+                  className="bg-dark-900 rounded-xl border border-dark-800 p-4 mb-3"
+                  accessibilityLabel="Loading domain"
+                >
+                  <View className="flex-row items-center">
+                    <View className="w-10 h-10 rounded-full bg-dark-800" />
+                    <View className="flex-1 ml-3">
+                      <View className="h-4 w-28 rounded bg-dark-800 mb-2" />
+                      <View className="h-3 w-48 rounded bg-dark-800" />
+                    </View>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+
+          {/* Load error */}
+          {walletReady && loadState.kind === "error" && (
+            <View className="bg-dark-900 rounded-xl border border-red-500/30 p-5">
+              <View className="flex-row items-center mb-1">
+                <WarningIcon
+                  size={18}
+                  color={ICON_COLORS.error}
+                  weight="fill"
+                />
+                <Text className="text-red-400 font-medium ml-2">
+                  Failed to load domains
+                </Text>
+              </View>
+              <Text className="text-dark-400 text-sm">
+                {loadState.message}
+              </Text>
+            </View>
+          )}
+
+          {/* Empty: no domains */}
+          {walletReady &&
+            loadState.kind === "loaded" &&
+            loadState.domains.length === 0 && (
+              <View className="bg-dark-900 rounded-xl border border-dark-800 p-6 items-center">
+                <View className="w-14 h-14 rounded-full bg-dark-800 items-center justify-center mb-3">
+                  <GlobeIcon
+                    size={24}
+                    color={ICON_COLORS.muted}
+                    weight="regular"
+                  />
+                </View>
+                <Text className="text-white font-medium text-base mb-1">
+                  No .sol domains found
+                </Text>
+                <Text className="text-dark-500 text-sm text-center mb-4">
+                  You don&apos;t own any .sol domains yet. Get one at sns.id
+                  to enable private payments.
+                </Text>
+                <TouchableOpacity
+                  onPress={() => Linking.openURL("https://sns.id")}
+                  className="flex-row items-center bg-brand-600 rounded-xl px-4 py-2"
+                  accessibilityRole="link"
+                  accessibilityLabel="Get a .sol domain at sns.id"
+                >
+                  <Text className="text-white font-semibold text-sm mr-1.5">
+                    Get a .sol domain
+                  </Text>
+                  <ArrowSquareOutIcon
+                    size={14}
+                    color={ICON_COLORS.white}
+                    weight="bold"
+                  />
+                </TouchableOpacity>
+              </View>
+            )}
+
+          {/* Domain cards */}
+          {walletReady &&
+            loadState.kind === "loaded" &&
+            loadState.domains.length > 0 && (
+              <View>
+                {loadState.domains.map((entry) => {
+                  const data: CardData =
+                    cards[entry.pubkey] ?? {
+                      state: "loading",
+                      domainName: entry.fullDomain,
+                      signature: null,
+                      errorMessage: null,
+                    }
+                  return (
+                    <DomainCard
+                      key={entry.pubkey}
+                      entry={entry}
+                      data={data}
+                      network={network}
+                      explorer={defaultExplorer}
+                      onPublish={() => handlePublish(entry)}
+                    />
+                  )
+                })}
+              </View>
+            )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+// ============================================================================
+// CARD
+// ============================================================================
+
+interface DomainCardProps {
+  entry: DomainEntry
+  data: CardData
+  network: "mainnet-beta" | "devnet" | "testnet"
+  explorer: ReturnType<typeof useSettingsStore.getState>["defaultExplorer"]
+  onPublish: () => void
+}
+
+function DomainCard({
+  entry,
+  data,
+  network,
+  explorer,
+  onPublish,
+}: DomainCardProps) {
+  const { state, domainName, signature, errorMessage } = data
+  const displayName = domainName ?? entry.fullDomain
+
+  // Loading skeleton (per-card).
+  if (state === "loading") {
+    return (
+      <View
+        className="bg-dark-900 rounded-xl border border-dark-800 p-4 mb-3"
+        accessibilityLabel={`Checking ${displayName}`}
+      >
+        <View className="flex-row items-center">
+          <View className="w-10 h-10 rounded-full bg-dark-800 items-center justify-center">
+            <GlobeIcon
+              size={18}
+              color={ICON_COLORS.muted}
+              weight="regular"
+            />
+          </View>
+          <View className="flex-1 ml-3">
+            <Text className="text-white font-semibold text-sm" numberOfLines={1}>
+              {displayName}
+            </Text>
+            <Text className="text-dark-500 text-xs mt-0.5">
+              Checking record…
+            </Text>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  if (state === "error") {
+    return (
+      <View className="bg-dark-900 rounded-xl border border-red-500/20 p-4 mb-3">
+        <View className="flex-row items-center">
+          <View className="w-10 h-10 rounded-full bg-red-900/30 items-center justify-center">
+            <WarningIcon
+              size={18}
+              color={ICON_COLORS.error}
+              weight="fill"
+            />
+          </View>
+          <View className="flex-1 ml-3">
+            <Text className="text-white font-semibold text-sm" numberOfLines={1}>
+              {displayName}
+            </Text>
+            <Text className="text-red-400 text-xs mt-0.5">
+              {errorMessage ?? "Failed to load"}
+            </Text>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  if (state === "has-record") {
+    return (
+      <View className="bg-dark-900 rounded-xl border border-dark-800 p-4 mb-3">
+        <View className="flex-row items-center">
+          <View className="w-10 h-10 rounded-full bg-green-900/30 items-center justify-center">
+            <CheckCircleIcon
+              size={18}
+              color={ICON_COLORS.success}
+              weight="fill"
+            />
+          </View>
+          <View className="flex-1 ml-3">
+            <Text className="text-white font-semibold text-sm" numberOfLines={1}>
+              {displayName}
+            </Text>
+            <Text className="text-green-400 text-xs mt-0.5">
+              Private payments enabled
+            </Text>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  if (state === "published") {
+    const explorerUrl = signature
+      ? getExplorerTxUrl(signature, network, explorer)
+      : null
+    return (
+      <View className="bg-dark-900 rounded-xl border border-green-500/30 p-4 mb-3">
+        <View className="flex-row items-center">
+          <View className="w-10 h-10 rounded-full bg-green-900/30 items-center justify-center">
+            <CheckCircleIcon
+              size={18}
+              color={ICON_COLORS.success}
+              weight="fill"
+            />
+          </View>
+          <View className="flex-1 ml-3">
+            <Text className="text-white font-semibold text-sm" numberOfLines={1}>
+              {displayName}
+            </Text>
+            <Text className="text-green-400 text-xs mt-0.5">
+              Published successfully
+            </Text>
+          </View>
+        </View>
+        {explorerUrl && (
+          <TouchableOpacity
+            className="flex-row items-center mt-3 self-start"
+            onPress={() => Linking.openURL(explorerUrl)}
+            accessibilityRole="link"
+            accessibilityLabel={`View transaction on ${getExplorerName(explorer)}`}
+          >
+            <Text className="text-brand-400 text-xs font-medium mr-1">
+              View on {getExplorerName(explorer)}
+            </Text>
+            <ArrowSquareOutIcon
+              size={12}
+              color={ICON_COLORS.brand}
+              weight="bold"
+            />
+          </TouchableOpacity>
+        )}
+      </View>
+    )
+  }
+
+  // no-record / publishing
+  const isPublishing = state === "publishing"
+
+  return (
+    <View className="bg-dark-900 rounded-xl border border-dark-800 p-4 mb-3">
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center flex-1 min-w-0">
+          <View className="w-10 h-10 rounded-full bg-dark-800 items-center justify-center">
+            <GlobeIcon
+              size={18}
+              color={ICON_COLORS.muted}
+              weight="regular"
+            />
+          </View>
+          <View className="flex-1 ml-3 min-w-0">
+            <Text
+              className="text-white font-semibold text-sm"
+              numberOfLines={1}
+            >
+              {displayName}
+            </Text>
+            <Text className="text-dark-500 text-xs mt-0.5">
+              No SIP stealth record
+            </Text>
+          </View>
+        </View>
+
+        <TouchableOpacity
+          onPress={onPublish}
+          disabled={isPublishing}
+          accessibilityRole="button"
+          accessibilityLabel={
+            isPublishing
+              ? `Publishing private payments for ${displayName}`
+              : `Enable private payments for ${displayName}`
+          }
+          accessibilityState={{ disabled: isPublishing, busy: isPublishing }}
+          className={
+            isPublishing
+              ? "bg-brand-600/50 rounded-xl px-4 py-2 ml-3"
+              : "bg-brand-600 rounded-xl px-4 py-2 ml-3"
+          }
+        >
+          <Text className="text-white font-semibold text-sm">
+            {isPublishing ? "Publishing…" : "Enable"}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {errorMessage && (
+        <View className="flex-row items-center mt-3">
+          <WarningIcon
+            size={12}
+            color={ICON_COLORS.error}
+            weight="fill"
+          />
+          <Text className="text-red-400 text-xs ml-1.5 flex-1">
+            {errorMessage}
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "e2e:test:android:att": "detox test --configuration android.att.debug"
   },
   "dependencies": {
+    "@bonfida/spl-name-service": "^3.0.21",
     "@coral-xyz/anchor": "^0.30.0",
     "@ethersproject/shims": "^5.8.0",
     "@expo/vector-icons": "^15.0.3",
@@ -34,6 +35,7 @@
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@sip-protocol/sdk": "^0.7.3",
+    "@sip-protocol/sns-stealth": "^0.1.0",
     "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.5",
     "@solana-mobile/seed-vault-lib": "0.4.0",
     "@solana/web3.js": "^1.98.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   .:
     dependencies:
+      '@bonfida/spl-name-service':
+        specifier: ^3.0.21
+        version: 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@coral-xyz/anchor':
         specifier: ^0.30.0
         version: 0.30.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -55,6 +58,9 @@ importers:
       '@sip-protocol/sdk':
         specifier: ^0.7.3
         version: 0.7.3(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@sip-protocol/sns-stealth':
+        specifier: ^0.1.0
+        version: 0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana-mobile/mobile-wallet-adapter-protocol-web3js':
         specifier: ^2.2.5
         version: 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)
@@ -786,6 +792,16 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bonfida/sns-records@0.1.0':
+    resolution: {integrity: sha512-/viuqvsjvAUjFxzqX0L3ZntfK1S5K1Nj+j2avxq2tCXhA2Ee7Qt0gPCaQKuMv3hh8cKAEMaZ8crZHomns3UuqA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.87.3
+
+  '@bonfida/spl-name-service@3.0.21':
+    resolution: {integrity: sha512-dYKZwG2ColaDUvX+ZrzcPtE6sQcNNwXywMsLit57Z+bKSEYQdIFxncrDSSzjLKcxQRFPUQObptaSEcv+ZwcMQA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.98.2
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1906,6 +1922,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
@@ -1932,6 +1951,9 @@ packages:
 
   '@sip-protocol/sdk@0.7.3':
     resolution: {integrity: sha512-b1aWFNG0TyzhHcIk5wJhvf9sKgmW5y2uVKUtXNmSsBlwTOLnIr75pTMVXcTF4Ri3RhkTTlq9GT1eBHkYyuM6Vg==}
+
+  '@sip-protocol/sns-stealth@0.1.0':
+    resolution: {integrity: sha512-XPb7gSQf+ie7MmNXr9vpZU69UvO5/XWDqrfECel1m65UBu20F+/3ohFeD4TmowkJ4f6UHkA1HCNxMv9y6Slc4A==}
 
   '@sip-protocol/types@0.2.1':
     resolution: {integrity: sha512-wDX8T2Oav9NzyZbNxiA+u6E/BvSk34ylaCyhj+LMDL3NMJ2RFc2Sud65+DjFGImVPpym4LH8Hpi/et2OLCfJ6Q==}
@@ -1962,6 +1984,9 @@ packages:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    resolution: {integrity: sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==}
+
   '@solana/codecs-core@2.0.0-rc.1':
     resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
     peerDependencies:
@@ -1979,10 +2004,16 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    resolution: {integrity: sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==}
+
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    resolution: {integrity: sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==}
 
   '@solana/codecs-numbers@2.0.0-rc.1':
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
@@ -2001,6 +2032,11 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-strings@2.0.0-preview.2':
+    resolution: {integrity: sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
@@ -2014,10 +2050,17 @@ packages:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5.3.3'
 
+  '@solana/codecs@2.0.0-preview.2':
+    resolution: {integrity: sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==}
+
   '@solana/codecs@2.0.0-rc.1':
     resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/errors@2.0.0-preview.2':
+    resolution: {integrity: sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==}
+    hasBin: true
 
   '@solana/errors@2.0.0-rc.1':
     resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
@@ -2039,10 +2082,19 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/options@2.0.0-preview.2':
+    resolution: {integrity: sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==}
+
   '@solana/options@2.0.0-rc.1':
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/spl-token-group@0.0.4':
+    resolution: {integrity: sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
 
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
@@ -2061,6 +2113,16 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
+
+  '@solana/spl-token@0.4.6':
+    resolution: {integrity: sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
+  '@solana/spl-type-length-value@0.1.0':
+    resolution: {integrity: sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==}
+    engines: {node: '>=16'}
 
   '@solana/wallet-adapter-base@0.9.27':
     resolution: {integrity: sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg==}
@@ -2719,6 +2781,12 @@ packages:
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  borsh@1.0.0:
+    resolution: {integrity: sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
@@ -3887,6 +3955,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphemesplit@2.6.0:
+    resolution: {integrity: sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -4000,6 +4071,10 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -5008,6 +5083,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -5902,6 +5980,9 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -6054,6 +6135,9 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unimodules-app-loader@6.0.8:
     resolution: {integrity: sha512-fqS8QwT/MC/HAmw1NKCHdzsPA6WaLm0dNmoC5Pz6lL+cDGYeYCNdHMO9fy08aL2ZD7cVkNM0pSR/AoNRe+rslA==}
@@ -6412,6 +6496,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.10:
     resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}
@@ -7065,6 +7152,32 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bonfida/sns-records@0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 1.0.0
+      bs58: 5.0.0
+      buffer: 6.0.3
+
+  '@bonfida/spl-name-service@3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/sns-records': 0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@noble/curves': 1.9.7
+      '@scure/base': 1.2.6
+      '@solana/spl-token': 0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 2.0.0
+      buffer: 6.0.3
+      graphemesplit: 2.6.0
+      ipaddr.js: 2.4.0
+      punycode: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@colors/colors@1.6.0': {}
 
@@ -8442,6 +8555,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.56.0':
     optional: true
 
+  '@scure/base@1.2.6': {}
+
   '@scure/base@2.0.0': {}
 
   '@scure/bip32@2.0.1':
@@ -8484,6 +8599,20 @@ snapshots:
       '@sip-protocol/types': 0.2.1
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@sip-protocol/sns-stealth@0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/spl-name-service': 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      zod: 4.4.3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -8547,6 +8676,10 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    dependencies:
+      '@solana/errors': 2.0.0-preview.2
+
   '@solana/codecs-core@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
@@ -8562,12 +8695,23 @@ snapshots:
       '@solana/errors': 4.0.0(typescript@5.9.3)
       typescript: 5.9.3
 
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
+
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
       typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -8587,6 +8731,13 @@ snapshots:
       '@solana/errors': 4.0.0(typescript@5.9.3)
       typescript: 5.9.3
 
+  '@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
+      fastestsmallesttextencoderdecoder: 1.0.22
+
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -8603,6 +8754,16 @@ snapshots:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
+  '@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-data-structures': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/codecs-strings': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/options': 2.0.0-preview.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -8613,6 +8774,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0-preview.2':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
 
   '@solana/errors@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -8632,6 +8798,11 @@ snapshots:
       commander: 14.0.1
       typescript: 5.9.3
 
+  '@solana/options@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+
   '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -8640,6 +8811,14 @@ snapshots:
       '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/spl-token-group@0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-type-length-value': 0.1.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
@@ -8673,6 +8852,25 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
+
+  '@solana/spl-token@0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-type-length-value@0.1.0':
+    dependencies:
+      buffer: 6.0.3
 
   '@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -9466,6 +9664,10 @@ snapshots:
       bn.js: 5.2.2
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
+
+  borsh@1.0.0: {}
+
+  borsh@2.0.0: {}
 
   bplist-creator@0.1.0:
     dependencies:
@@ -10741,6 +10943,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphemesplit@2.6.0:
+    dependencies:
+      js-base64: 3.7.8
+      unicode-trie: 2.0.0
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -10849,6 +11056,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ipaddr.js@2.4.0: {}
 
   is-arguments@1.2.0:
     dependencies:
@@ -12221,6 +12430,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@0.2.9: {}
+
   pako@2.1.0: {}
 
   parent-module@1.0.1:
@@ -13180,6 +13391,8 @@ snapshots:
 
   throat@5.0.0: {}
 
+  tiny-inflate@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -13282,6 +13495,11 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unimodules-app-loader@6.0.8: {}
 
@@ -13660,6 +13878,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.10(@types/react@19.1.17)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)):
     optionalDependencies:

--- a/src/lib/recipient-resolution.ts
+++ b/src/lib/recipient-resolution.ts
@@ -1,0 +1,164 @@
+/**
+ * Types and pure helpers for the recipient resolution state machine.
+ *
+ * Mirrors sip-app's `recipient-resolution.ts` BUT adds a `solana-address`
+ * kind so raw Solana addresses are first-class: sip-mobile supports
+ * transparent sends (sip-app does not), so the send screen's submit gate
+ * must accept a base58 pubkey as a ready-to-send state.
+ *
+ * Kept React- and async-free so:
+ *   1. Tests can import it without pulling in `@bonfida/spl-name-service`
+ *      (which crashes the vitest-node environment — Task 16 footnote).
+ *   2. The send screen can compose it with its existing useEffect-based
+ *      state machine instead of swallowing a second hook.
+ */
+
+import {
+  SOLANA_ADDRESS_REGEX,
+  STEALTH_ADDRESS_REGEX,
+} from "@/utils/validation"
+
+// ── Regex constants ───────────────────────────────────────────────────────────
+
+/**
+ * Re-export under the same identifier sip-app uses, so future cross-repo
+ * refactors can keep using the canonical name. Source of truth lives in
+ * `src/utils/validation.ts` — do NOT redefine here.
+ */
+export const SIP_ADDRESS_REGEX = STEALTH_ADDRESS_REGEX
+
+export { SOLANA_ADDRESS_REGEX }
+
+/**
+ * SNS domain: one or more labels (alphanumeric + hyphen) separated by
+ * dots, ending in .sol (case-insensitive). Supports sub-subdomains
+ * (e.g. `foo.bar.sol`) the same way Bonfida itself does.
+ */
+export const SNS_DOMAIN_REGEX = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.sol$/i
+
+// ── Resolution state tagged union ─────────────────────────────────────────────
+
+/** The recipient input has been cleared. */
+export type REmpty = { kind: "empty" }
+
+/** A valid sip:solana:… URI — ready to send (stealth). */
+export type RSipUri = { kind: "sip-uri"; uri: string }
+
+/**
+ * A raw base58 Solana address — ready to send (transparent).
+ * sip-mobile-specific extension vs sip-app (which is SNS- and sip:-only).
+ */
+export type RSolanaAddress = { kind: "solana-address"; address: string }
+
+/** A .sol domain is being resolved over the network. */
+export type RSnsResolving = { kind: "sns-resolving"; domain: string }
+
+/**
+ * SIP-STEALTH record found for the domain — ready to send.
+ * `uri` is the constructed sip:solana:… string.
+ */
+export type RSnsResolved = { kind: "sns-resolved"; domain: string; uri: string }
+
+/**
+ * Domain exists but has no SIP-STEALTH record.
+ * Show warn-and-downgrade UX (view public address + cancel).
+ */
+export type RSnsNotFoundRecord = {
+  kind: "sns-not-found-record"
+  domain: string
+}
+
+/** Domain not registered on SNS. Red error. */
+export type RSnsNotFoundDomain = {
+  kind: "sns-not-found-domain"
+  domain: string
+}
+
+/** Domain exists but the SIP-STEALTH record is malformed. Red error. */
+export type RSnsMalformed = {
+  kind: "sns-malformed"
+  domain: string
+  reason: string
+}
+
+/** Input matches neither a sip: URI nor a .sol domain nor a base58 pubkey. */
+export type RInvalid = { kind: "invalid"; input: string }
+
+export type RecipientResolution =
+  | REmpty
+  | RSipUri
+  | RSolanaAddress
+  | RSnsResolving
+  | RSnsResolved
+  | RSnsNotFoundRecord
+  | RSnsNotFoundDomain
+  | RSnsMalformed
+  | RInvalid
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Return true when the resolution represents a ready-to-send state.
+ *
+ * `solana-address` is intentionally included here (the sip-mobile
+ * extension): the existing send flow accepts a base58 recipient and
+ * routes it through the transparent path.
+ */
+export function isReadyToSend(
+  r: RecipientResolution
+): r is RSipUri | RSolanaAddress | RSnsResolved {
+  return (
+    r.kind === "sip-uri" ||
+    r.kind === "solana-address" ||
+    r.kind === "sns-resolved"
+  )
+}
+
+/**
+ * Extract the actual string to hand to the send call.
+ *
+ * - `sip-uri` and `sns-resolved` → the `sip:solana:<spend>:<view>` URI
+ * - `solana-address` → the raw base58 string
+ * - everything else → null (not ready to send)
+ */
+export function targetUri(r: RecipientResolution): string | null {
+  if (r.kind === "sip-uri") return r.uri
+  if (r.kind === "sns-resolved") return r.uri
+  if (r.kind === "solana-address") return r.address
+  return null
+}
+
+/**
+ * Classify a raw input string into the initial resolution state (no I/O).
+ *
+ * Precedence:
+ *   1. sip:solana:… URI  → `sip-uri`
+ *   2. *.sol domain      → `sns-resolving` (async path)
+ *   3. base58 pubkey     → `solana-address`
+ *   4. anything else     → `invalid`
+ *
+ * Empty / whitespace-only → `empty`.
+ */
+export function classifyInput(raw: string): RecipientResolution {
+  // Strip trailing dot ("alice.sol." → "alice.sol") and surrounding whitespace.
+  const trimmed = raw.trim().replace(/\.$/, "")
+  if (trimmed === "") return { kind: "empty" }
+
+  if (SIP_ADDRESS_REGEX.test(trimmed)) {
+    return { kind: "sip-uri", uri: trimmed }
+  }
+
+  // SNS check before Solana base58: a hypothetical lowercase 32-44 char
+  // string ending in ".sol" would otherwise match the (loose) base58
+  // regex — but the dot itself is NOT in the base58 alphabet, so this
+  // ordering is conservative. Kept explicit for the future reader.
+  if (SNS_DOMAIN_REGEX.test(trimmed)) {
+    return { kind: "sns-resolving", domain: trimmed.toLowerCase() }
+  }
+
+  if (SOLANA_ADDRESS_REGEX.test(trimmed)) {
+    return { kind: "solana-address", address: trimmed }
+  }
+
+  return { kind: "invalid", input: trimmed }
+}

--- a/src/lib/sns-stealth-mobile.ts
+++ b/src/lib/sns-stealth-mobile.ts
@@ -1,0 +1,98 @@
+/**
+ * SNS-STEALTH wrapper for sip-mobile.
+ *
+ * Mirrors the sip-app wrapper at src/lib/sns-stealth-client.ts: callers pass a
+ * Connection (so cluster selection is respected) and a minimal wallet shape
+ * compatible with useNativeWallet's signMessage/signTransaction primitives.
+ *
+ * Error classes are re-exported here so consumers have one integration point
+ * and `instanceof` discrimination keeps working across the wrapper boundary.
+ */
+
+import type { Connection, PublicKey, Transaction } from "@solana/web3.js"
+import {
+  resolveSIPStealth,
+  buildPublishTx,
+  deriveStealthKeys,
+  invalidateCache,
+  MetaAddress,
+  Malformed,
+  NetworkError,
+  NotFound,
+  OnChainError,
+  UserRejected,
+  type ResolveResult,
+} from "@sip-protocol/sns-stealth"
+
+/**
+ * Minimal wallet shape required to publish a SIP-STEALTH record.
+ *
+ * - `signMessage` derives the deterministic stealth keys (DKSAP via HKDF).
+ * - `signTransaction` signs the on-chain publish tx in-place and returns it.
+ *
+ * Compatible with useNativeWallet (PRIMARY) and any external adapter that
+ * exposes the same two callbacks.
+ */
+export interface PublishWallet {
+  publicKey: PublicKey
+  signMessage: (message: Uint8Array) => Promise<Uint8Array>
+  signTransaction: (tx: Transaction) => Promise<Transaction>
+}
+
+/**
+ * Resolve a `.sol` domain to a SIP stealth MetaAddress (or typed not-found / malformed).
+ *
+ * @param connection - Solana RPC connection (caller-provided so cluster is respected)
+ * @param domain - Full `.sol` domain (e.g., "alice.sol")
+ */
+export async function resolve(
+  connection: Connection,
+  domain: string
+): Promise<ResolveResult> {
+  return resolveSIPStealth(connection, domain)
+}
+
+/**
+ * Publish a SIP-STEALTH record on the caller's `.sol` domain.
+ *
+ * Deterministically derives per-domain stealth keys from the wallet's signed
+ * message, builds the SNS record-write transaction, has the wallet sign it,
+ * and submits via the same connection.
+ *
+ * Throws `UserRejected` if the wallet declines signing; other typed errors
+ * (NetworkError, OnChainError, Malformed) bubble up from the SDK.
+ */
+export async function publish(
+  connection: Connection,
+  domain: string,
+  wallet: PublishWallet
+): Promise<{ signature: string }> {
+  const keys = await deriveStealthKeys(
+    { signMessage: wallet.signMessage },
+    domain
+  )
+
+  const tx = await buildPublishTx(
+    connection,
+    domain,
+    { spending: keys.spending, viewing: keys.viewing },
+    wallet.publicKey
+  )
+
+  const signed = await wallet.signTransaction(tx)
+  const signature = await connection.sendRawTransaction(signed.serialize())
+
+  invalidateCache(domain)
+  return { signature }
+}
+
+export {
+  invalidateCache,
+  MetaAddress,
+  Malformed,
+  NetworkError,
+  NotFound,
+  OnChainError,
+  UserRejected,
+}
+export type { ResolveResult }

--- a/src/utils/sipStealthHelpers.ts
+++ b/src/utils/sipStealthHelpers.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure helpers for the SIP-STEALTH Publish Screen.
+ *
+ * Lives in `src/utils` (instead of inline in the screen file) so the tests
+ * can import them WITHOUT pulling in `@bonfida/spl-name-service`,
+ * `phosphor-react-native`, or any React/RN module transitively. The screen
+ * re-exports these from `app/settings/sip-stealth.tsx`.
+ *
+ * The same shape exists in sip-app's PublishCard — discriminated union for
+ * the card state, error class discrimination via `instanceof`, and an
+ * exhaustiveness guard on the resolve result.
+ */
+
+import type { PublicKey } from "@solana/web3.js"
+import {
+  MetaAddress,
+  NotFound,
+  Malformed,
+  NetworkError,
+  OnChainError,
+  UserRejected,
+  type ResolveResult,
+} from "@sip-protocol/sns-stealth"
+
+// ─── Card state machine ────────────────────────────────────────────────────
+
+/**
+ * Per-card state machine.
+ *
+ * `loading` is the initial state (resolving the existing record).
+ * `has-record` and `no-record` are terminal until the user acts.
+ * `publishing` is the in-flight state for the user's enable action.
+ * `published` is the post-success state with a tx signature available.
+ * `error` covers card-load failures (network, parsing). Publish failures
+ * roll back to `no-record` with `errorMessage` set so the user can retry.
+ */
+export type CardState =
+  | "loading"
+  | "has-record"
+  | "no-record"
+  | "publishing"
+  | "published"
+  | "error"
+
+export interface CardData {
+  state: CardState
+  domainName: string | null
+  signature: string | null
+  errorMessage: string | null
+}
+
+/**
+ * Classify a resolve result into a card state. Exhaustive on the union.
+ *
+ * Returns `"has-record"` when the domain already publishes a valid stealth
+ * meta-address, `"no-record"` when SNS itself is missing the record or the
+ * record bytes don't parse (the user can simply (re)publish to fix that),
+ * and the explicit `_exhaustive` branch lets the compiler enforce that any
+ * new ResolveResult variant gets a deliberate decision here.
+ */
+export function classifyResolveResult(
+  result: ResolveResult
+): "has-record" | "no-record" {
+  if (result instanceof MetaAddress) return "has-record"
+  if (result instanceof NotFound) return "no-record"
+  if (result instanceof Malformed) return "no-record"
+  const _exhaustive: never = result
+  throw new Error(`Unhandled resolve result: ${String(_exhaustive)}`)
+}
+
+// ─── Error classification ──────────────────────────────────────────────────
+
+/**
+ * Map a publish-time error to a user-facing message.
+ *
+ * `UserRejected` is treated as a soft signal (the user cancelled at the
+ * biometric prompt), so it gets a friendly message rather than a scary one.
+ * `NetworkError` is retryable. `OnChainError` carries a real on-chain
+ * failure with a signature attached (worth showing). Everything else
+ * falls through to the message string with a generic prefix.
+ */
+export function errorMessageFor(err: unknown): string {
+  if (err instanceof UserRejected) {
+    return "You cancelled the request"
+  }
+  if (err instanceof NetworkError) {
+    return "Network error — try again"
+  }
+  if (err instanceof OnChainError) {
+    return `On-chain error: ${err.message}`
+  }
+  if (err instanceof Error) {
+    return `Failed to publish: ${err.message}`
+  }
+  return "Failed to publish: unknown error"
+}
+
+/**
+ * Map a load-time error (resolve / getAllDomains) to a user-facing message.
+ *
+ * Same instanceof discrimination as `errorMessageFor`, but the strings are
+ * load-time appropriate (no "Failed to publish" prefix).
+ */
+export function loadErrorMessageFor(err: unknown): string {
+  if (err instanceof NetworkError) {
+    return "Network error — try again"
+  }
+  if (err instanceof Error) {
+    return err.message
+  }
+  return "Failed to load record"
+}
+
+// ─── Wallet readiness ──────────────────────────────────────────────────────
+
+/**
+ * Wallet readiness gate. Returns true only when the native wallet is
+ * fully initialized AND a wallet is loaded AND we're not mid-loading.
+ *
+ * This is the boolean the screen uses to decide between the
+ * "connect a wallet" empty state and the actual domain list.
+ */
+export function isWalletReady(opts: {
+  wallet: { publicKey: PublicKey } | null
+  isInitialized: boolean
+  isLoading: boolean
+}): boolean {
+  return !!opts.wallet && opts.isInitialized && !opts.isLoading
+}

--- a/src/utils/sipStealthHelpers.ts
+++ b/src/utils/sipStealthHelpers.ts
@@ -50,25 +50,69 @@ export interface CardData {
 }
 
 /**
- * Classify a resolve result into a card state. Exhaustive on the union.
+ * Compile-time exhaustiveness witness for ResolveResult.
+ *
+ * If a new ResolveResult variant is ever added upstream, this assignment
+ * will fail to type-check unless the new variant is also added to the
+ * union below — preserving the "every variant must be handled" contract
+ * that the previous `_exhaustive: never = result` line provided. We keep
+ * this here (instead of inside `classifyResolveResult`) because the
+ * function takes `unknown` to avoid casts at call sites, and `unknown`
+ * can't be narrowed to `never`.
+ */
+type _ExhaustiveResolveCheck =
+  ResolveResult extends MetaAddress | NotFound | Malformed ? true : never
+const _exhaustiveResolveCheck: _ExhaustiveResolveCheck = true
+void _exhaustiveResolveCheck
+
+/**
+ * Classify a resolve result into a card state.
  *
  * Returns `"has-record"` when the domain already publishes a valid stealth
  * meta-address, `"no-record"` when SNS itself is missing the record or the
  * record bytes don't parse (the user can simply (re)publish to fix that),
- * and the explicit `_exhaustive` branch lets the compiler enforce that any
- * new ResolveResult variant gets a deliberate decision here.
+ * and throws for any other value.
+ *
+ * Parameter is widened to `unknown` so callers/tests don't need to cast
+ * non-ResolveResult inputs through `as unknown as ResolveResult`. We
+ * validate the shape inside via `instanceof` (the wrapper preserves class
+ * identity across the boundary), and throw on anything else.
  */
 export function classifyResolveResult(
-  result: ResolveResult
+  result: unknown
 ): "has-record" | "no-record" {
   if (result instanceof MetaAddress) return "has-record"
   if (result instanceof NotFound) return "no-record"
   if (result instanceof Malformed) return "no-record"
-  const _exhaustive: never = result
-  throw new Error(`Unhandled resolve result: ${String(_exhaustive)}`)
+  throw new Error(`Unhandled resolve result: ${String(result)}`)
 }
 
 // ─── Error classification ──────────────────────────────────────────────────
+
+/**
+ * Shape thrown by `useNativeWallet.signTransaction` / `signMessage` when
+ * biometric auth is cancelled or fails. NOT an `Error` instance — it's a
+ * plain object — so the generic `instanceof Error` branch in
+ * `errorMessageFor` would miss it.
+ *
+ * See: src/hooks/useNativeWallet.ts:439-446 (signing path) and
+ *      src/utils/keyStorage.ts:345-355 (auth-cancel re-throw).
+ */
+interface NativeWalletErrorLike {
+  code: string
+  message: string
+}
+
+function isNativeWalletErrorLike(err: unknown): err is NativeWalletErrorLike {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "code" in err &&
+    "message" in err &&
+    typeof (err as Record<string, unknown>).code === "string" &&
+    typeof (err as Record<string, unknown>).message === "string"
+  )
+}
 
 /**
  * Map a publish-time error to a user-facing message.
@@ -76,8 +120,18 @@ export function classifyResolveResult(
  * `UserRejected` is treated as a soft signal (the user cancelled at the
  * biometric prompt), so it gets a friendly message rather than a scary one.
  * `NetworkError` is retryable. `OnChainError` carries a real on-chain
- * failure with a signature attached (worth showing). Everything else
+ * failure with a signature attached (and its message already includes the
+ * "On-chain error" prefix — see packages/sns-stealth/src/errors.ts:41 —
+ * so we render it as-is to avoid double-prefixing). Everything else
  * falls through to the message string with a generic prefix.
+ *
+ * Note on `NativeWalletErrorLike`: the native wallet hook throws a plain
+ * object (`{code, message}`) on biometric cancel/failure rather than a
+ * typed `UserRejected` instance. Without this branch, that path would
+ * miss every `instanceof` check above and render
+ * "Failed to publish: unknown error" — confusing UX for a user who just
+ * tapped Cancel. We map `SIGNING_FAILED` / `AUTH_FAILED` to the same
+ * friendly cancellation message and surface other codes verbatim.
  */
 export function errorMessageFor(err: unknown): string {
   if (err instanceof UserRejected) {
@@ -87,9 +141,15 @@ export function errorMessageFor(err: unknown): string {
     return "Network error — try again"
   }
   if (err instanceof OnChainError) {
-    return `On-chain error: ${err.message}`
+    return err.message
   }
   if (err instanceof Error) {
+    return `Failed to publish: ${err.message}`
+  }
+  if (isNativeWalletErrorLike(err)) {
+    if (err.code === "SIGNING_FAILED" || err.code === "AUTH_FAILED") {
+      return "You cancelled the request"
+    }
     return `Failed to publish: ${err.message}`
   }
   return "Failed to publish: unknown error"

--- a/tests/lib/recipientResolution.test.ts
+++ b/tests/lib/recipientResolution.test.ts
@@ -137,6 +137,18 @@ describe("classifyInput", () => {
       const r = classifyInput("SIP:solana:" + SOLANA_ADDR + ":" + SOLANA_ADDR)
       expect(r.kind).toBe("invalid")
     })
+
+    it("strips trailing dot from sip-uri", () => {
+      // classifyInput strips a single trailing dot before matching, so a
+      // sip-uri with a stray trailing "." (e.g. pasted from a sentence) still
+      // classifies as sip-uri. Locks the contract that the strip is applied
+      // before the SIP_ADDRESS_REGEX test, not just before SNS_DOMAIN_REGEX.
+      const r = classifyInput(SIP_URI + ".")
+      expect(r.kind).toBe("sip-uri")
+      if (r.kind === "sip-uri") {
+        expect(r.uri).toBe(SIP_URI)
+      }
+    })
   })
 
   describe(".sol domain", () => {

--- a/tests/lib/recipientResolution.test.ts
+++ b/tests/lib/recipientResolution.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Recipient Resolution — Pure Logic Tests
+ *
+ * Covers the recipient resolution state machine helpers in
+ * `src/lib/recipient-resolution.ts`:
+ *   - classifyInput: raw string → initial RecipientResolution
+ *   - isReadyToSend: resolution → boolean (with narrowing predicate)
+ *   - targetUri: resolution → string | null (send-call target)
+ *
+ * The module is pure TypeScript with no async / no Bonfida / no React, so
+ * tests import it directly without any mocks. Same convention as
+ * tests/screens/sipStealth.test.ts.
+ */
+
+import { describe, it, expect } from "vitest"
+import {
+  classifyInput,
+  isReadyToSend,
+  targetUri,
+  SIP_ADDRESS_REGEX,
+  SOLANA_ADDRESS_REGEX,
+  SNS_DOMAIN_REGEX,
+  type RecipientResolution,
+} from "@/lib/recipient-resolution"
+
+// ============================================================================
+// FIXTURES
+// ============================================================================
+
+// Stealth meta-address: sip:solana:<spend(base58)>:<view(base58)>
+const SIP_URI =
+  "sip:solana:7x3Fh9wkY1qZc8N5pL2dM8N4F1J3v9eQ7P6oH2K9T4Z:2Bp4kL1M9wN3qF6X5oV2cH7K8jR4dT6yP9aS3uG2nE5W"
+
+// Standard 44-char base58 Solana pubkey
+const SOLANA_ADDR = "S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at"
+// 32-char base58 pubkey (also valid)
+const SHORTER_ADDR = "11111111111111111111111111111111"
+
+const ALICE_SOL = "alice.sol"
+const SUB_SUB_SOL = "foo.bar.sol"
+
+// ============================================================================
+// REGEX SANITY (re-export contract)
+// ============================================================================
+
+describe("regex re-exports", () => {
+  it("SIP_ADDRESS_REGEX accepts a valid stealth URI", () => {
+    expect(SIP_ADDRESS_REGEX.test(SIP_URI)).toBe(true)
+  })
+
+  it("SIP_ADDRESS_REGEX rejects a plain base58 pubkey", () => {
+    expect(SIP_ADDRESS_REGEX.test(SOLANA_ADDR)).toBe(false)
+  })
+
+  it("SOLANA_ADDRESS_REGEX accepts a 44-char base58 pubkey", () => {
+    expect(SOLANA_ADDRESS_REGEX.test(SOLANA_ADDR)).toBe(true)
+  })
+
+  it("SOLANA_ADDRESS_REGEX accepts a 32-char base58 pubkey", () => {
+    expect(SOLANA_ADDRESS_REGEX.test(SHORTER_ADDR)).toBe(true)
+  })
+
+  it("SOLANA_ADDRESS_REGEX rejects too-short input", () => {
+    expect(SOLANA_ADDRESS_REGEX.test("abc")).toBe(false)
+  })
+
+  it("SOLANA_ADDRESS_REGEX rejects too-long input", () => {
+    expect(SOLANA_ADDRESS_REGEX.test("a".repeat(50))).toBe(false)
+  })
+
+  it("SNS_DOMAIN_REGEX accepts a single-label .sol", () => {
+    expect(SNS_DOMAIN_REGEX.test(ALICE_SOL)).toBe(true)
+  })
+
+  it("SNS_DOMAIN_REGEX accepts a sub-subdomain", () => {
+    expect(SNS_DOMAIN_REGEX.test(SUB_SUB_SOL)).toBe(true)
+  })
+
+  it("SNS_DOMAIN_REGEX is case-insensitive", () => {
+    expect(SNS_DOMAIN_REGEX.test("Alice.SOL")).toBe(true)
+  })
+
+  it("SNS_DOMAIN_REGEX rejects non-.sol TLDs", () => {
+    expect(SNS_DOMAIN_REGEX.test("alice.eth")).toBe(false)
+    expect(SNS_DOMAIN_REGEX.test("alice")).toBe(false)
+  })
+})
+
+// ============================================================================
+// classifyInput
+// ============================================================================
+
+describe("classifyInput", () => {
+  describe("empty / whitespace inputs", () => {
+    it("classifies empty string as empty", () => {
+      expect(classifyInput("")).toEqual({ kind: "empty" })
+    })
+
+    it("classifies whitespace-only as empty", () => {
+      expect(classifyInput("   ")).toEqual({ kind: "empty" })
+    })
+
+    it("classifies tab + newline as empty", () => {
+      expect(classifyInput("\t\n")).toEqual({ kind: "empty" })
+    })
+  })
+
+  describe("sip: URI", () => {
+    it("classifies a valid sip:solana URI as sip-uri", () => {
+      const r = classifyInput(SIP_URI)
+      expect(r.kind).toBe("sip-uri")
+      if (r.kind === "sip-uri") {
+        expect(r.uri).toBe(SIP_URI)
+      }
+    })
+
+    it("trims surrounding whitespace in sip-uri", () => {
+      const r = classifyInput(`  ${SIP_URI}  `)
+      expect(r.kind).toBe("sip-uri")
+      if (r.kind === "sip-uri") {
+        expect(r.uri).toBe(SIP_URI)
+      }
+    })
+
+    it("rejects a sip: URI with a non-solana chain (lowercase)", () => {
+      const r = classifyInput("sip:ethereum:abc:def")
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("rejects a malformed sip: URI (missing viewing key)", () => {
+      const r = classifyInput("sip:solana:" + SOLANA_ADDR)
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("rejects a mixed-case sip-uri (sip: prefix is lowercase)", () => {
+      // STEALTH_ADDRESS_REGEX requires exact "sip:solana:" prefix.
+      const r = classifyInput("SIP:solana:" + SOLANA_ADDR + ":" + SOLANA_ADDR)
+      expect(r.kind).toBe("invalid")
+    })
+  })
+
+  describe(".sol domain", () => {
+    it("classifies a bare .sol domain as sns-resolving", () => {
+      const r = classifyInput(ALICE_SOL)
+      expect(r.kind).toBe("sns-resolving")
+      if (r.kind === "sns-resolving") {
+        expect(r.domain).toBe(ALICE_SOL)
+      }
+    })
+
+    it("classifies a sub-subdomain as sns-resolving", () => {
+      const r = classifyInput(SUB_SUB_SOL)
+      expect(r.kind).toBe("sns-resolving")
+      if (r.kind === "sns-resolving") {
+        expect(r.domain).toBe(SUB_SUB_SOL)
+      }
+    })
+
+    it("strips a trailing dot before classification", () => {
+      const r = classifyInput("alice.sol.")
+      expect(r.kind).toBe("sns-resolving")
+      if (r.kind === "sns-resolving") {
+        expect(r.domain).toBe(ALICE_SOL)
+      }
+    })
+
+    it("lowercases uppercase .sol input", () => {
+      const r = classifyInput("Alice.SOL")
+      expect(r.kind).toBe("sns-resolving")
+      if (r.kind === "sns-resolving") {
+        expect(r.domain).toBe(ALICE_SOL)
+      }
+    })
+
+    it("trims surrounding whitespace in domains", () => {
+      const r = classifyInput("  alice.sol  ")
+      expect(r.kind).toBe("sns-resolving")
+      if (r.kind === "sns-resolving") {
+        expect(r.domain).toBe(ALICE_SOL)
+      }
+    })
+
+    it("rejects non-.sol TLD as invalid (not sns-resolving)", () => {
+      const r = classifyInput("alice.eth")
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("rejects a single label without TLD as invalid", () => {
+      const r = classifyInput("alice")
+      expect(r.kind).toBe("invalid")
+    })
+  })
+
+  describe("solana base58 address", () => {
+    it("classifies a 44-char base58 string as solana-address", () => {
+      const r = classifyInput(SOLANA_ADDR)
+      expect(r.kind).toBe("solana-address")
+      if (r.kind === "solana-address") {
+        expect(r.address).toBe(SOLANA_ADDR)
+      }
+    })
+
+    it("classifies a 32-char base58 string as solana-address", () => {
+      const r = classifyInput(SHORTER_ADDR)
+      expect(r.kind).toBe("solana-address")
+      if (r.kind === "solana-address") {
+        expect(r.address).toBe(SHORTER_ADDR)
+      }
+    })
+
+    it("rejects a base58-ish string that's too short", () => {
+      const r = classifyInput("abc123")
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("rejects a base58-ish string that's too long", () => {
+      const r = classifyInput("a".repeat(50))
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("rejects '0' (forbidden in base58 alphabet)", () => {
+      const r = classifyInput("0".repeat(44))
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("rejects 'O', 'I', 'l' (forbidden in base58 alphabet)", () => {
+      const r1 = classifyInput("O".repeat(44))
+      const r2 = classifyInput("I".repeat(44))
+      const r3 = classifyInput("l".repeat(44))
+      expect(r1.kind).toBe("invalid")
+      expect(r2.kind).toBe("invalid")
+      expect(r3.kind).toBe("invalid")
+    })
+
+    it("a sip: prefix on the input does NOT classify as solana-address", () => {
+      // Defensive: sip: takes precedence; a malformed sip: URI falls through
+      // to invalid (NOT to solana-address) because the leading "sip:" is
+      // not in the base58 alphabet.
+      const r = classifyInput("sip:" + SOLANA_ADDR)
+      expect(r.kind).toBe("invalid")
+    })
+
+    it("trims surrounding whitespace in base58 addresses", () => {
+      const r = classifyInput(`  ${SOLANA_ADDR}  `)
+      expect(r.kind).toBe("solana-address")
+      if (r.kind === "solana-address") {
+        expect(r.address).toBe(SOLANA_ADDR)
+      }
+    })
+  })
+
+  describe("invalid inputs", () => {
+    it("classifies arbitrary garbage as invalid", () => {
+      const r = classifyInput("@@@!!!")
+      expect(r.kind).toBe("invalid")
+      if (r.kind === "invalid") {
+        expect(r.input).toBe("@@@!!!")
+      }
+    })
+
+    it("preserves the trimmed input in the invalid kind", () => {
+      const r = classifyInput("  bogus  ")
+      expect(r.kind).toBe("invalid")
+      if (r.kind === "invalid") {
+        expect(r.input).toBe("bogus")
+      }
+    })
+  })
+
+  describe("precedence ordering", () => {
+    it("sip: URI takes precedence over base58 (if both could match)", () => {
+      // SIP_ADDRESS_REGEX is checked first; the sip: prefix can't also be a
+      // valid base58 pubkey, but we lock the precedence contract here.
+      const r = classifyInput(SIP_URI)
+      expect(r.kind).toBe("sip-uri")
+    })
+
+    it(".sol takes precedence over base58", () => {
+      // Same: a .sol domain has a dot, which is not in base58 alphabet —
+      // but we lock the contract.
+      const r = classifyInput(ALICE_SOL)
+      expect(r.kind).toBe("sns-resolving")
+    })
+  })
+})
+
+// ============================================================================
+// isReadyToSend
+// ============================================================================
+
+describe("isReadyToSend", () => {
+  it("returns true for sip-uri", () => {
+    const r: RecipientResolution = { kind: "sip-uri", uri: SIP_URI }
+    expect(isReadyToSend(r)).toBe(true)
+  })
+
+  it("returns true for solana-address (sip-mobile extension)", () => {
+    const r: RecipientResolution = {
+      kind: "solana-address",
+      address: SOLANA_ADDR,
+    }
+    expect(isReadyToSend(r)).toBe(true)
+  })
+
+  it("returns true for sns-resolved", () => {
+    const r: RecipientResolution = {
+      kind: "sns-resolved",
+      domain: ALICE_SOL,
+      uri: SIP_URI,
+    }
+    expect(isReadyToSend(r)).toBe(true)
+  })
+
+  it("returns false for empty", () => {
+    expect(isReadyToSend({ kind: "empty" })).toBe(false)
+  })
+
+  it("returns false for sns-resolving (still in flight)", () => {
+    expect(
+      isReadyToSend({ kind: "sns-resolving", domain: ALICE_SOL })
+    ).toBe(false)
+  })
+
+  it("returns false for sns-not-found-record", () => {
+    expect(
+      isReadyToSend({ kind: "sns-not-found-record", domain: ALICE_SOL })
+    ).toBe(false)
+  })
+
+  it("returns false for sns-not-found-domain", () => {
+    expect(
+      isReadyToSend({ kind: "sns-not-found-domain", domain: ALICE_SOL })
+    ).toBe(false)
+  })
+
+  it("returns false for sns-malformed", () => {
+    expect(
+      isReadyToSend({
+        kind: "sns-malformed",
+        domain: ALICE_SOL,
+        reason: "schema",
+      })
+    ).toBe(false)
+  })
+
+  it("returns false for invalid", () => {
+    expect(isReadyToSend({ kind: "invalid", input: "@@@" })).toBe(false)
+  })
+
+  it("acts as a type narrowing predicate (compile-time check)", () => {
+    const r: RecipientResolution = { kind: "sip-uri", uri: SIP_URI }
+    if (isReadyToSend(r)) {
+      // After narrowing, TS should know r is RSipUri | RSolanaAddress | RSnsResolved
+      // — `targetUri(r)` must return a string (not null).
+      const t = targetUri(r)
+      expect(typeof t).toBe("string")
+    }
+  })
+})
+
+// ============================================================================
+// targetUri
+// ============================================================================
+
+describe("targetUri", () => {
+  it("returns the URI for sip-uri", () => {
+    const r: RecipientResolution = { kind: "sip-uri", uri: SIP_URI }
+    expect(targetUri(r)).toBe(SIP_URI)
+  })
+
+  it("returns the URI for sns-resolved", () => {
+    const r: RecipientResolution = {
+      kind: "sns-resolved",
+      domain: ALICE_SOL,
+      uri: SIP_URI,
+    }
+    expect(targetUri(r)).toBe(SIP_URI)
+  })
+
+  it("returns the raw address for solana-address", () => {
+    const r: RecipientResolution = {
+      kind: "solana-address",
+      address: SOLANA_ADDR,
+    }
+    expect(targetUri(r)).toBe(SOLANA_ADDR)
+  })
+
+  it("returns null for empty", () => {
+    expect(targetUri({ kind: "empty" })).toBeNull()
+  })
+
+  it("returns null for sns-resolving", () => {
+    expect(
+      targetUri({ kind: "sns-resolving", domain: ALICE_SOL })
+    ).toBeNull()
+  })
+
+  it("returns null for sns-not-found-record", () => {
+    expect(
+      targetUri({ kind: "sns-not-found-record", domain: ALICE_SOL })
+    ).toBeNull()
+  })
+
+  it("returns null for sns-not-found-domain", () => {
+    expect(
+      targetUri({ kind: "sns-not-found-domain", domain: ALICE_SOL })
+    ).toBeNull()
+  })
+
+  it("returns null for sns-malformed", () => {
+    expect(
+      targetUri({
+        kind: "sns-malformed",
+        domain: ALICE_SOL,
+        reason: "schema",
+      })
+    ).toBeNull()
+  })
+
+  it("returns null for invalid", () => {
+    expect(targetUri({ kind: "invalid", input: "@@@" })).toBeNull()
+  })
+})
+
+// ============================================================================
+// Send-screen integration contract (logic-level)
+// ============================================================================
+//
+// These tests don't import the screen file (which would pull in Bonfida via
+// the resolution effect and crash vitest-node). They lock the contract
+// between resolution kind → derived isStealth + targetUri output, which is
+// the state-machine consumer surface in app/send/index.tsx.
+
+describe("Send screen integration — derived isStealth", () => {
+  // Same derivation as app/send/index.tsx: stealth iff sip-uri or sns-resolved.
+  function deriveIsStealth(r: RecipientResolution): boolean {
+    return r.kind === "sip-uri" || r.kind === "sns-resolved"
+  }
+
+  it("isStealth = true for sip-uri", () => {
+    expect(deriveIsStealth({ kind: "sip-uri", uri: SIP_URI })).toBe(true)
+  })
+
+  it("isStealth = true for sns-resolved", () => {
+    expect(
+      deriveIsStealth({
+        kind: "sns-resolved",
+        domain: ALICE_SOL,
+        uri: SIP_URI,
+      })
+    ).toBe(true)
+  })
+
+  it("isStealth = false for solana-address (transparent send)", () => {
+    expect(
+      deriveIsStealth({ kind: "solana-address", address: SOLANA_ADDR })
+    ).toBe(false)
+  })
+
+  it("isStealth = false for all not-ready kinds", () => {
+    expect(deriveIsStealth({ kind: "empty" })).toBe(false)
+    expect(
+      deriveIsStealth({ kind: "sns-resolving", domain: ALICE_SOL })
+    ).toBe(false)
+    expect(
+      deriveIsStealth({ kind: "sns-not-found-record", domain: ALICE_SOL })
+    ).toBe(false)
+    expect(
+      deriveIsStealth({ kind: "sns-not-found-domain", domain: ALICE_SOL })
+    ).toBe(false)
+    expect(
+      deriveIsStealth({
+        kind: "sns-malformed",
+        domain: ALICE_SOL,
+        reason: "schema",
+      })
+    ).toBe(false)
+    expect(deriveIsStealth({ kind: "invalid", input: "x" })).toBe(false)
+  })
+})
+
+describe("Send screen integration — submit-gate + send-target", () => {
+  // Same fallback as handleConfirmSend in the screen: targetUri ?? recipient.
+  function deriveSendTarget(
+    r: RecipientResolution,
+    rawRecipient: string
+  ): string {
+    return targetUri(r) ?? rawRecipient
+  }
+
+  it("uses the resolved sip: URI for sns-resolved (NOT the raw .sol)", () => {
+    const target = deriveSendTarget(
+      { kind: "sns-resolved", domain: ALICE_SOL, uri: SIP_URI },
+      "alice.sol"
+    )
+    expect(target).toBe(SIP_URI)
+    expect(target).not.toBe("alice.sol")
+  })
+
+  it("uses the raw URI for sip-uri", () => {
+    const target = deriveSendTarget(
+      { kind: "sip-uri", uri: SIP_URI },
+      SIP_URI
+    )
+    expect(target).toBe(SIP_URI)
+  })
+
+  it("uses the raw base58 for solana-address", () => {
+    const target = deriveSendTarget(
+      { kind: "solana-address", address: SOLANA_ADDR },
+      SOLANA_ADDR
+    )
+    expect(target).toBe(SOLANA_ADDR)
+  })
+
+  it("falls back to the raw recipient when targetUri returns null", () => {
+    // This branch is unreachable in practice (submit gate would have blocked
+    // the call), but we lock the fallback contract anyway.
+    const target = deriveSendTarget({ kind: "empty" }, "")
+    expect(target).toBe("")
+  })
+
+  it("submit gate (isReadyToSend) and send-target stay consistent", () => {
+    // Property: whenever isReadyToSend returns true, targetUri returns
+    // non-null. The send screen's submit handler relies on this.
+    const ready: RecipientResolution[] = [
+      { kind: "sip-uri", uri: SIP_URI },
+      { kind: "solana-address", address: SOLANA_ADDR },
+      { kind: "sns-resolved", domain: ALICE_SOL, uri: SIP_URI },
+    ]
+    for (const r of ready) {
+      expect(isReadyToSend(r)).toBe(true)
+      expect(targetUri(r)).not.toBeNull()
+    }
+  })
+})

--- a/tests/screens/sipStealth.test.ts
+++ b/tests/screens/sipStealth.test.ts
@@ -1,0 +1,320 @@
+/**
+ * SIP-STEALTH Publish Screen — Logic Tests
+ *
+ * Covers the pure helpers extracted from `app/settings/sip-stealth.tsx`:
+ *   - classifyResolveResult: ResolveResult → CardState classification
+ *   - errorMessageFor: publish error → user-facing message
+ *   - isWalletReady: native wallet boolean gate
+ *
+ * Plus the explorer URL helpers the screen renders into the "View on …"
+ * link (verifies cluster-aware reactivity).
+ *
+ * Logic-level tests, no React Testing Library — matches the convention
+ * in tests/screens/send.test.ts.
+ */
+
+import { describe, it, expect } from "vitest"
+import { PublicKey } from "@solana/web3.js"
+import {
+  MetaAddress,
+  NotFound,
+  Malformed,
+  NetworkError,
+  OnChainError,
+  UserRejected,
+} from "@sip-protocol/sns-stealth"
+import {
+  classifyResolveResult,
+  errorMessageFor,
+  isWalletReady,
+  loadErrorMessageFor,
+} from "@/utils/sipStealthHelpers"
+import { getExplorerTxUrl } from "@/utils/explorer"
+
+// ============================================================================
+// FIXTURES
+// ============================================================================
+
+const ZERO_KEY_32 = new Uint8Array(32) // valid length for spending/viewing key
+const MOCK_DOMAIN = "alice.sol"
+const MOCK_TX = "5xyzabc123def456ghi789jkl012mno345pqr678stu901vwx234yz"
+const MOCK_PUBKEY = new PublicKey("S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at")
+
+function makeMetaAddress(): MetaAddress {
+  return new MetaAddress(ZERO_KEY_32, ZERO_KEY_32, "solana", MOCK_DOMAIN)
+}
+
+// ============================================================================
+// classifyResolveResult
+// ============================================================================
+
+describe("classifyResolveResult", () => {
+  it("maps a valid MetaAddress to 'has-record'", () => {
+    const meta = makeMetaAddress()
+    expect(classifyResolveResult(meta)).toBe("has-record")
+  })
+
+  it("maps NotFound('domain') to 'no-record'", () => {
+    const result = new NotFound("domain")
+    expect(classifyResolveResult(result)).toBe("no-record")
+  })
+
+  it("maps NotFound('record') to 'no-record'", () => {
+    const result = new NotFound("record")
+    expect(classifyResolveResult(result)).toBe("no-record")
+  })
+
+  it("maps Malformed('json-parse') to 'no-record' so user can republish", () => {
+    const result = new Malformed("json-parse")
+    expect(classifyResolveResult(result)).toBe("no-record")
+  })
+
+  it("maps Malformed('schema') to 'no-record' so user can republish", () => {
+    const result = new Malformed("schema")
+    expect(classifyResolveResult(result)).toBe("no-record")
+  })
+
+  it("treats MetaAddress as an instance check (not duck-typing)", () => {
+    // A plain object with the same shape should NOT classify as has-record;
+    // the wrapper preserves the class identity across the boundary, and
+    // we rely on that for correctness. classifyResolveResult uses instanceof.
+    const fake = {
+      spending: ZERO_KEY_32,
+      viewing: ZERO_KEY_32,
+      chain: "solana",
+      domain: MOCK_DOMAIN,
+    } as unknown
+    // Should fall through to the exhaustive guard and throw.
+    expect(() =>
+      classifyResolveResult(fake as Parameters<typeof classifyResolveResult>[0])
+    ).toThrow(/Unhandled resolve result/)
+  })
+})
+
+// ============================================================================
+// errorMessageFor
+// ============================================================================
+
+describe("errorMessageFor", () => {
+  it("returns a friendly message for UserRejected (biometric cancel)", () => {
+    const err = new UserRejected()
+    expect(errorMessageFor(err)).toBe("You cancelled the request")
+  })
+
+  it("returns a network-specific message for NetworkError", () => {
+    const err = new NetworkError("RPC timeout")
+    expect(errorMessageFor(err)).toBe("Network error — try again")
+  })
+
+  it("returns an on-chain message with details for OnChainError", () => {
+    const err = new OnChainError(MOCK_TX, "insufficient lamports")
+    const msg = errorMessageFor(err)
+    expect(msg).toContain("On-chain error")
+    expect(msg).toContain("insufficient lamports")
+  })
+
+  it("returns a generic 'Failed to publish' message for any other Error", () => {
+    const err = new Error("something exploded")
+    expect(errorMessageFor(err)).toBe("Failed to publish: something exploded")
+  })
+
+  it("returns a generic message for string thrown values", () => {
+    expect(errorMessageFor("blah" as unknown)).toBe(
+      "Failed to publish: unknown error"
+    )
+  })
+
+  it("returns a generic message for undefined", () => {
+    expect(errorMessageFor(undefined)).toBe(
+      "Failed to publish: unknown error"
+    )
+  })
+
+  it("returns a generic message for null", () => {
+    expect(errorMessageFor(null)).toBe("Failed to publish: unknown error")
+  })
+
+  it("preserves Error message content (no truncation/sanitization)", () => {
+    const longMsg = "x".repeat(200)
+    const err = new Error(longMsg)
+    expect(errorMessageFor(err)).toBe(`Failed to publish: ${longMsg}`)
+  })
+
+  it("checks UserRejected first (it's a subclass of Error)", () => {
+    // Regression guard: if branch ordering ever flips, this still catches it
+    // because UserRejected is `instanceof Error`.
+    const err = new UserRejected("user dismissed prompt")
+    expect(errorMessageFor(err)).toBe("You cancelled the request")
+    expect(errorMessageFor(err)).not.toContain("user dismissed prompt")
+  })
+})
+
+// ============================================================================
+// loadErrorMessageFor (resolve / getAllDomains failure messages)
+// ============================================================================
+
+describe("loadErrorMessageFor", () => {
+  it("returns retry hint for NetworkError", () => {
+    const err = new NetworkError("RPC unavailable")
+    expect(loadErrorMessageFor(err)).toBe("Network error — try again")
+  })
+
+  it("returns the Error message for any other Error", () => {
+    const err = new Error("parse failure")
+    expect(loadErrorMessageFor(err)).toBe("parse failure")
+  })
+
+  it("returns a generic message for non-Error throwables", () => {
+    expect(loadErrorMessageFor("boom" as unknown)).toBe("Failed to load record")
+    expect(loadErrorMessageFor(null)).toBe("Failed to load record")
+    expect(loadErrorMessageFor(undefined)).toBe("Failed to load record")
+  })
+
+  it("does NOT prefix with 'Failed to publish' (it's a load-time helper)", () => {
+    const err = new Error("anything")
+    expect(loadErrorMessageFor(err)).not.toContain("publish")
+  })
+})
+
+// ============================================================================
+// isWalletReady
+// ============================================================================
+
+describe("isWalletReady", () => {
+  const mockWallet = { publicKey: MOCK_PUBKEY }
+
+  it("returns true when wallet present, initialized, not loading", () => {
+    expect(
+      isWalletReady({
+        wallet: mockWallet,
+        isInitialized: true,
+        isLoading: false,
+      })
+    ).toBe(true)
+  })
+
+  it("returns false when wallet is null", () => {
+    expect(
+      isWalletReady({
+        wallet: null,
+        isInitialized: true,
+        isLoading: false,
+      })
+    ).toBe(false)
+  })
+
+  it("returns false when not initialized (still booting)", () => {
+    expect(
+      isWalletReady({
+        wallet: mockWallet,
+        isInitialized: false,
+        isLoading: false,
+      })
+    ).toBe(false)
+  })
+
+  it("returns false during loading (e.g., create/import in flight)", () => {
+    expect(
+      isWalletReady({
+        wallet: mockWallet,
+        isInitialized: true,
+        isLoading: true,
+      })
+    ).toBe(false)
+  })
+
+  it("returns false on the initial-load state (null + loading + uninitialized)", () => {
+    expect(
+      isWalletReady({
+        wallet: null,
+        isInitialized: false,
+        isLoading: true,
+      })
+    ).toBe(false)
+  })
+})
+
+// ============================================================================
+// Explorer URL derivation (used in the "Published" card)
+// ============================================================================
+
+describe("Published card explorer URL", () => {
+  it("uses Solscan with no cluster param on mainnet", () => {
+    const url = getExplorerTxUrl(MOCK_TX, "mainnet-beta", "solscan")
+    expect(url).toBe(`https://solscan.io/tx/${MOCK_TX}`)
+    expect(url).not.toContain("cluster")
+  })
+
+  it("uses Solscan with cluster=devnet on devnet", () => {
+    const url = getExplorerTxUrl(MOCK_TX, "devnet", "solscan")
+    expect(url).toBe(`https://solscan.io/tx/${MOCK_TX}?cluster=devnet`)
+  })
+
+  it("respects the user's Solana Explorer preference on mainnet", () => {
+    const url = getExplorerTxUrl(MOCK_TX, "mainnet-beta", "solana-explorer")
+    expect(url).toBe(`https://explorer.solana.com/tx/${MOCK_TX}`)
+  })
+
+  it("respects the user's Solana Explorer preference on devnet", () => {
+    const url = getExplorerTxUrl(MOCK_TX, "devnet", "solana-explorer")
+    expect(url).toBe(
+      `https://explorer.solana.com/tx/${MOCK_TX}?cluster=devnet`
+    )
+  })
+
+  it("rebuilds URL when network changes (cluster-aware reactivity)", () => {
+    // Simulates: user publishes on mainnet, then switches cluster — the
+    // explorer link must reflect the *current* settings, not the network
+    // at publish time. The screen reads `network` from useSettingsStore
+    // every render, so a re-render with a different value rebuilds the
+    // URL via this helper.
+    const mainnet = getExplorerTxUrl(MOCK_TX, "mainnet-beta", "solscan")
+    const devnet = getExplorerTxUrl(MOCK_TX, "devnet", "solscan")
+    expect(mainnet).not.toBe(devnet)
+  })
+})
+
+// ============================================================================
+// Error classification — integration with publish flow shape
+// ============================================================================
+
+describe("Publish flow error roll-back", () => {
+  it("UserRejected leaves the card recoverable (no-record + soft message)", () => {
+    // The screen rolls publish failures back to 'no-record' state with the
+    // user-facing message attached. This test asserts the contract between
+    // errorMessageFor and the card state shape.
+    const err = new UserRejected()
+    const msg = errorMessageFor(err)
+    expect(msg).toBe("You cancelled the request")
+    // The screen sets state to 'no-record' so the Enable button is shown
+    // again — verified by structural shape:
+    const card = {
+      state: "no-record" as const,
+      domainName: MOCK_DOMAIN,
+      signature: null,
+      errorMessage: msg,
+    }
+    expect(card.state).toBe("no-record")
+    expect(card.errorMessage).toBe("You cancelled the request")
+    expect(card.signature).toBeNull()
+  })
+
+  it("NetworkError leaves the card recoverable with retry hint", () => {
+    const err = new NetworkError("ECONNRESET")
+    const msg = errorMessageFor(err)
+    expect(msg).toBe("Network error — try again")
+    const card = {
+      state: "no-record" as const,
+      errorMessage: msg,
+    }
+    expect(card.state).toBe("no-record")
+    expect(card.errorMessage).toContain("try again")
+  })
+
+  it("OnChainError surfaces the on-chain context in the card message", () => {
+    const err = new OnChainError(MOCK_TX, "blockhash not found")
+    const msg = errorMessageFor(err)
+    expect(msg).toContain("On-chain error")
+    expect(msg).toContain("blockhash not found")
+  })
+})

--- a/tests/screens/sipStealth.test.ts
+++ b/tests/screens/sipStealth.test.ts
@@ -78,16 +78,16 @@ describe("classifyResolveResult", () => {
     // A plain object with the same shape should NOT classify as has-record;
     // the wrapper preserves the class identity across the boundary, and
     // we rely on that for correctness. classifyResolveResult uses instanceof.
+    // The helper accepts `unknown` so this needs no casts.
     const fake = {
       spending: ZERO_KEY_32,
       viewing: ZERO_KEY_32,
       chain: "solana",
       domain: MOCK_DOMAIN,
-    } as unknown
-    // Should fall through to the exhaustive guard and throw.
-    expect(() =>
-      classifyResolveResult(fake as Parameters<typeof classifyResolveResult>[0])
-    ).toThrow(/Unhandled resolve result/)
+    }
+    expect(() => classifyResolveResult(fake)).toThrow(
+      /Unhandled resolve result/
+    )
   })
 })
 
@@ -106,11 +106,16 @@ describe("errorMessageFor", () => {
     expect(errorMessageFor(err)).toBe("Network error — try again")
   })
 
-  it("returns an on-chain message with details for OnChainError", () => {
+  it("returns the on-chain error message verbatim (no double prefix)", () => {
+    // OnChainError.message is already "On-chain error (<sig>): <reason>"
+    // — see packages/sns-stealth/src/errors.ts:41 — so the helper must
+    // surface it as-is. The previous "On-chain error: ${err.message}"
+    // wrapper produced "On-chain error: On-chain error (sig): reason".
     const err = new OnChainError(MOCK_TX, "insufficient lamports")
     const msg = errorMessageFor(err)
-    expect(msg).toContain("On-chain error")
-    expect(msg).toContain("insufficient lamports")
+    expect(msg).toBe(`On-chain error (${MOCK_TX}): insufficient lamports`)
+    // Sanity: no double "On-chain error" prefix.
+    expect(msg.match(/On-chain error/g)?.length ?? 0).toBe(1)
   })
 
   it("returns a generic 'Failed to publish' message for any other Error", () => {
@@ -146,6 +151,45 @@ describe("errorMessageFor", () => {
     const err = new UserRejected("user dismissed prompt")
     expect(errorMessageFor(err)).toBe("You cancelled the request")
     expect(errorMessageFor(err)).not.toContain("user dismissed prompt")
+  })
+
+  it("maps the native-wallet SIGNING_FAILED plain object to the cancel UX", () => {
+    // useNativeWallet.signTransaction (src/hooks/useNativeWallet.ts:439-446)
+    // catches biometric-cancel from getPrivateKeyForAccount and re-throws a
+    // plain object `{code: 'SIGNING_FAILED', message: '...'}` — NOT an
+    // `Error` instance and NOT a UserRejected instance. Without an explicit
+    // branch, this falls through every `instanceof` check and lands on the
+    // generic "Failed to publish: unknown error", which reads as a crash
+    // to a user who just tapped Cancel at the biometric prompt.
+    const err = { code: "SIGNING_FAILED", message: "Failed to sign transaction" }
+    expect(errorMessageFor(err)).toBe("You cancelled the request")
+  })
+
+  it("maps the native-wallet AUTH_FAILED plain object to the cancel UX", () => {
+    // Same path, different code — keyStorage.ts:351 re-throws AUTH_FAILED
+    // when SecureStore reports cancelled biometric auth, and that bubbles
+    // up through signTransaction's catch block unchanged in some flows.
+    const err = { code: "AUTH_FAILED", message: "Biometric authentication failed" }
+    expect(errorMessageFor(err)).toBe("You cancelled the request")
+  })
+
+  it("surfaces non-cancel native-wallet error codes verbatim", () => {
+    // Other native-wallet codes (e.g. STORAGE_ERROR) aren't user-cancellations;
+    // we still want the message visible rather than masked as "unknown error".
+    const err = { code: "STORAGE_ERROR", message: "Disk full" }
+    expect(errorMessageFor(err)).toBe("Failed to publish: Disk full")
+  })
+
+  it("does not match arbitrary objects as native-wallet errors", () => {
+    // Defensive: only `{code: string, message: string}` shapes pass the gate;
+    // anything else falls through to the generic unknown-error fallback.
+    expect(errorMessageFor({ code: 123, message: "x" })).toBe(
+      "Failed to publish: unknown error"
+    )
+    expect(errorMessageFor({ code: "X" })).toBe(
+      "Failed to publish: unknown error"
+    )
+    expect(errorMessageFor({})).toBe("Failed to publish: unknown error")
   })
 })
 


### PR DESCRIPTION
## Summary

Phase C of the sip.sol foundation — wires `@sip-protocol/sns-stealth@0.1.0` into sip-mobile so users can publish SIP-STEALTH records on their `.sol` domains and pay private recipients by name. Closes the loop after [Phase A npm publish (sip-protocol#1082)](https://github.com/sip-protocol/sip-protocol/pull/1082) and [Phase B sip-app integration (sip-app#269)](https://github.com/sip-protocol/sip-app/pull/269).

Three tasks, five commits:

- **Task 15** (`1780465`) — Add `@sip-protocol/sns-stealth@^0.1.0` + `@bonfida/spl-name-service@^3.0.21` deps; create `src/lib/sns-stealth-mobile.ts` wrapper that accepts a caller-provided `Connection` (so cluster selection is respected) and a minimal `PublishWallet` shape compatible with `useNativeWallet`'s `signMessage`/`signTransaction` primitives. Re-exports all typed errors (`UserRejected`, `NetworkError`, `Malformed`, `NotFound`, `OnChainError`) so consumers can `instanceof`-discriminate from one integration point.
- **Task 16** (`9198b02` + fixup `1833c18`) — New screen at `app/settings/sip-stealth.tsx` listing the user's `.sol` domains via Bonfida `getAllDomains` + `reverseLookup`, checking each for an existing SIP-STEALTH record, and offering a per-domain "Enable" CTA. Cluster-aware `Connection` derived from `useSettingsStore`. Six per-card states + four screen-level states. Wires `useNativeWallet`'s `signTransaction` into the wrapper's `PublishWallet`. Pure helpers extracted to `src/utils/sipStealthHelpers.ts` (the screen file's transitive Bonfida import hangs vitest; helpers stay testable). Settings index gains a "Private Payments by Name" NavRow.
- **Task 17** (`e79f9af` + fixup `3033382`) — Send screen learns to resolve `.sol` recipients. State machine in `src/lib/recipient-resolution.ts` (pure TS, 9-kind tagged union extended with a `solana-address` kind to preserve transparent-send support — sip-mobile-specific, documented inline). 350ms debounce + generation counter ref + unmounted-guard ref mirror the Phase B safety contract. `targetUri(resolution) ?? recipient` is fed to the existing privacy-provider `send()` so the resolved `sip:` URI is the actual recipient. `not-found-record` warn UX with deferred "View public address" preview (no transparent submit — same scope decision as Phase B).

## Test Plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:run` — **62 suites / 1425 tests pass** (baseline 60/1323; +2 new suites, +102 net tests across both phases). Per-task unit / state-machine / error-classification / explorer-URL / wallet-readiness coverage. Critical regression guards added: SIGNING_FAILED biometric-cancel maps to UX path, OnChainError single-prefix guard, type-narrowing exhaustiveness witness for `ResolveResult`.
- [ ] Manual on Seeker — Settings → Private Payments by Name lists owned `.sol` domains, Enable triggers biometric prompt and publishes (mainnet)
- [ ] Manual on Seeker — Send → enter `alice.sol`, resolves to `sip:solana:…`, payment goes through; enter a non-SIP domain, see "View public address" preview; enter raw Solana base58, still hits transparent path
- [ ] Manual on Seeker — switch network/RPC mid-publish; settings change is gated while publish is in flight (Task 16 fixup C2)

## Architectural notes

- **Two-stage code review per task** caught issues that inline implementation would have missed: Task 16 had a dead `UserRejected` branch (native wallet rejects biometric cancel with a plain object, not the typed error class) and a publish-vs-settings-switch race; Task 17 had a stale-preview race in the deferred "View public address" path and a magic-string sentinel for `publicAddressPreview`. All fixed in their respective fixup commits.
- **Inline state machine in Send (not extracted as `RecipientInput`)** — deliberate deviation from Phase B's Option A architecture. sip-mobile's send screen is monolithic by design (no shared QR/contact modal), and a separate component adds RTL-testing pain without commensurate benefit. The pure-TS state-machine module IS extracted (`src/lib/recipient-resolution.ts`) and exhaustively tested.
- **Cluster-aware Connection** pattern is identical between the two new screens (`useMemo` keyed on `useSettingsStore` selectors). See follow-up #1 below.

## Known follow-ups (out of scope for this PR)

1. **Extract `useConnection()` hook** — the `useMemo<Connection>` block is duplicated verbatim between `app/settings/sip-stealth.tsx` and `app/send/index.tsx`. ~20 LOC win, trivial extraction. Cosmetic.
2. **`getRpcClient` singleton stomp** — `src/lib/rpc.ts:229-239` mutates a global singleton on every config call. Affects six call-sites repo-wide. This PR adds two new `TODO(rpc-singleton)` annotations consistent with the existing pre-existing-issue convention. Worth a dedicated `refactor(rpc)` PR.
3. **"Send Public" path is preview-only** — same as Phase B. Resolving the domain's SOL pointer for the not-found-record block shows the public address; submitting a transparent transfer to that address requires the existing send form to accept raw Solana addresses as recipients, which it already does — but wiring the UX path needs design first. Defer.
4. **Extract `<RecipientNotFoundRecord>` sub-component** — the 85-line warn block in `app/send/index.tsx` is the cleanest extraction candidate. Would also let it own its own gen-guard. Defer.

## Related

- [Phase A — npm publish (sip-protocol#1082)](https://github.com/sip-protocol/sip-protocol/pull/1082)
- [Phase B — sip-app integration (sip-app#269)](https://github.com/sip-protocol/sip-app/pull/269)
- Phase D (next) — sipher agent tools (`resolveSNS` + `sendPrivateToSNS`) so HERALD/Sipher chat can route private payments by `.sol` name