### PR TITLE
chore(deps): bump @sip-protocol/sns-stealth to ^0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@sip-protocol/sdk": "^0.7.3",
-    "@sip-protocol/sns-stealth": "^0.1.0",
+    "@sip-protocol/sns-stealth": "^0.1.1",
     "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.5",
     "@solana-mobile/seed-vault-lib": "0.4.0",
     "@solana/web3.js": "^1.98.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: ^0.7.3
         version: 0.7.3(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sip-protocol/sns-stealth':
-        specifier: ^0.1.0
-        version: 0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: ^0.1.1
+        version: 0.1.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana-mobile/mobile-wallet-adapter-protocol-web3js':
         specifier: ^2.2.5
         version: 2.2.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)
@@ -1952,8 +1952,8 @@ packages:
   '@sip-protocol/sdk@0.7.3':
     resolution: {integrity: sha512-b1aWFNG0TyzhHcIk5wJhvf9sKgmW5y2uVKUtXNmSsBlwTOLnIr75pTMVXcTF4Ri3RhkTTlq9GT1eBHkYyuM6Vg==}
 
-  '@sip-protocol/sns-stealth@0.1.0':
-    resolution: {integrity: sha512-XPb7gSQf+ie7MmNXr9vpZU69UvO5/XWDqrfECel1m65UBu20F+/3ohFeD4TmowkJ4f6UHkA1HCNxMv9y6Slc4A==}
+  '@sip-protocol/sns-stealth@0.1.1':
+    resolution: {integrity: sha512-11UD+wXDVnDisN6h432FKB3hHvi5jed/Bd9EOChmO2tV+JOd9R9Bg53E2aJ5zdxCdH9HXKos3RpqeKaLdkv8Lg==}
 
   '@sip-protocol/types@0.2.1':
     resolution: {integrity: sha512-wDX8T2Oav9NzyZbNxiA+u6E/BvSk34ylaCyhj+LMDL3NMJ2RFc2Sud65+DjFGImVPpym4LH8Hpi/et2OLCfJ6Q==}
@@ -8606,7 +8606,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@sip-protocol/sns-stealth@0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@sip-protocol/sns-stealth@0.1.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@bonfida/spl-name-service': 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/curves': 1.9.7


### PR DESCRIPTION
## Summary

Picks up [\`@sip-protocol/sns-stealth@0.1.1\`](https://www.npmjs.com/package/@sip-protocol/sns-stealth/v/0.1.1) which fixes the v0.1.0 publish bug: \`buildPublishTx\` only allocated the SNS record account but never wrote the data, so all published records were N bytes of zeros.

Mobile only consumes the **resolver** path (\`resolveSIPStealth\` for \`.sol\` recipients in Send), not the publisher, so this is a forward-compat bump — no behavior change in current builds. We pick it up so the next mobile build is on the same fixed package as sip-app and sipher.

Upstream fix: [sip-protocol/sip-protocol#1083](https://github.com/sip-protocol/sip-protocol/pull/1083).

## Test plan

- [x] \`pnpm install\` clean (with expected mobile-wallet-adapter bs58 peer warning, pre-existing)
- [ ] Next \`eas build --local\` consumes the bumped lockfile