### PR TITLE
feat(viewing-keys): enable view-only auditor import-scan (#86)

### DIFF
--- a/app/settings/viewing-keys/index.tsx
+++ b/app/settings/viewing-keys/index.tsx
@@ -184,9 +184,10 @@ interface ImportedKeyRowProps {
   importedKey: ImportedViewingKey
   onRemove: () => void
   onScan: () => void
+  scanning?: boolean
 }
 
-function ImportedKeyRow({ importedKey, onRemove, onScan }: ImportedKeyRowProps) {
+function ImportedKeyRow({ importedKey, onRemove, onScan, scanning }: ImportedKeyRowProps) {
   return (
     <View className="py-4 border-b border-dark-800">
       <View className="flex-row items-start">
@@ -217,9 +218,11 @@ function ImportedKeyRow({ importedKey, onRemove, onScan }: ImportedKeyRowProps) 
         <TouchableOpacity
           className="bg-brand-900/20 px-3 py-1.5 rounded-lg flex-row items-center gap-1"
           onPress={onScan}
+          disabled={scanning}
+          style={scanning ? { opacity: 0.5 } : undefined}
         >
           <MagnifyingGlassIcon size={14} color={ICON_COLORS.brand} weight="regular" />
-          <Text className="text-brand-400 text-sm">Scan</Text>
+          <Text className="text-brand-400 text-sm">{scanning ? "Scanning…" : "Scan"}</Text>
         </TouchableOpacity>
         <TouchableOpacity
           className="bg-dark-800 px-3 py-1.5 rounded-lg"
@@ -248,6 +251,7 @@ export default function ViewingKeysScreen() {
     deleteDisclosure,
     importViewingKey,
     removeImportedKey,
+    scanImportedKey,
     getActiveDisclosures,
   } = useViewingKeys()
   const { isConnected } = useWalletStore()
@@ -255,6 +259,7 @@ export default function ViewingKeysScreen() {
 
   const [activeTab, setActiveTab] = useState<Tab>("export")
   const [isExporting, setIsExporting] = useState(false)
+  const [scanningId, setScanningId] = useState<string | null>(null)
   const [showDisclosureModal, setShowDisclosureModal] = useState(false)
   const [showImportModal, setShowImportModal] = useState(false)
 
@@ -443,13 +448,35 @@ export default function ViewingKeysScreen() {
     [removeImportedKey, addToast]
   )
 
-  const handleScanImported = (_key: ImportedViewingKey) => {
-    addToast({
-      type: "info",
-      title: "Not yet available",
-      message: "Viewing key scanning requires background indexer integration — planned for a future release",
-    })
-  }
+  const handleScanImported = useCallback(
+    async (key: ImportedViewingKey) => {
+      if (scanningId) return
+      setScanningId(key.id)
+      try {
+        const result = await scanImportedKey(key.id)
+        if (!result) {
+          addToast({
+            type: "error",
+            title: "Couldn't scan",
+            message:
+              "If this key was imported earlier, remove and re-import it; otherwise check your network and try again.",
+          })
+          return
+        }
+        addToast({
+          type: result.found > 0 ? "success" : "info",
+          title: result.found > 0 ? "Payments found" : "No payments found",
+          message:
+            result.found > 0
+              ? `Found ${result.found} payment${result.found === 1 ? "" : "s"} in ${result.scanned} announcement${result.scanned === 1 ? "" : "s"}.`
+              : `Scanned ${result.scanned} announcement${result.scanned === 1 ? "" : "s"} — none match this key.`,
+        })
+      } finally {
+        setScanningId(null)
+      }
+    },
+    [scanImportedKey, scanningId, addToast]
+  )
 
   if (!isConnected) {
     return (
@@ -730,6 +757,7 @@ export default function ViewingKeysScreen() {
                       importedKey={key}
                       onRemove={() => handleRemoveImported(key.id, key.label)}
                       onScan={() => handleScanImported(key)}
+                      scanning={scanningId === key.id}
                     />
                   ))}
                 </View>

--- a/src/hooks/useViewingKeys.ts
+++ b/src/hooks/useViewingKeys.ts
@@ -17,6 +17,11 @@ import type {
   ViewingKeyExport,
   ChainType,
 } from "@/types"
+import { useSettingsStore } from "@/stores/settings"
+import { Connection } from "@solana/web3.js"
+import { fetchAllTransferRecords } from "@/lib/anchor/client"
+import { scanRecordsForOwner } from "@/services/recordOwnership"
+import { hexToBytes } from "@/lib/stealth"
 
 // ============================================================================
 // TYPES
@@ -42,6 +47,7 @@ export interface UseViewingKeysReturn {
   importViewingKey: (input: ImportKeyInput) => Promise<ImportedViewingKey | null>
   removeImportedKey: (id: string) => Promise<void>
   updateImportedKey: (id: string, updates: Partial<ImportedViewingKey>) => Promise<void>
+  scanImportedKey: (id: string) => Promise<{ found: number; scanned: number } | null>
 
   // Queries
   getActiveDisclosures: () => ViewingKeyDisclosure[]
@@ -168,6 +174,32 @@ function decodeExport(encoded: string): ViewingKeyExport | null {
     } catch {
       return null
     }
+  }
+}
+
+/**
+ * Build an ImportedViewingKey from a decoded export.
+ *
+ * Pure mapping (exported for testing). Carries `spendingPublicKey` from the export so the
+ * imported key can be scanned view-only — detection needs the viewing private key + the
+ * owner's spending public key (#86).
+ */
+export function buildImportedViewingKey(
+  exportData: ViewingKeyExport,
+  input: { label: string; ownerAddress?: string },
+  id: string,
+  importedAt: number
+): ImportedViewingKey {
+  return {
+    id,
+    label: input.label,
+    viewingPublicKey: exportData.viewingPublicKey,
+    viewingPrivateKey: exportData.viewingPrivateKey,
+    spendingPublicKey: exportData.spendingPublicKey,
+    ownerAddress: input.ownerAddress,
+    chain: exportData.chain,
+    importedAt,
+    paymentsFound: 0,
   }
 }
 
@@ -364,16 +396,12 @@ export function useViewingKeys(): UseViewingKeysReturn {
           return null
         }
 
-        const importedKey: ImportedViewingKey = {
-          id: generateId(),
-          label: input.label,
-          viewingPublicKey: exportData.viewingPublicKey,
-          viewingPrivateKey: exportData.viewingPrivateKey,
-          ownerAddress: input.ownerAddress,
-          chain: exportData.chain,
-          importedAt: Date.now(),
-          paymentsFound: 0,
-        }
+        const importedKey = buildImportedViewingKey(
+          exportData,
+          { label: input.label, ownerAddress: input.ownerAddress },
+          generateId(),
+          Date.now()
+        )
 
         const newKeys = [importedKey, ...importedKeys]
         await saveImportedKeys(newKeys)
@@ -404,6 +432,59 @@ export function useViewingKeys(): UseViewingKeysReturn {
       await saveImportedKeys(newKeys)
     },
     [importedKeys, saveImportedKeys]
+  )
+
+  /**
+   * Scan the chain for payments to an imported viewing key — VIEW-ONLY.
+   *
+   * Fetches transfer records and filters them with the canonical view-only check using the
+   * imported key's viewing private key + the owner's spending public key (never a spending
+   * private key). Updates the key's `lastScannedAt` / `paymentsFound`. Keys imported before
+   * `spendingPublicKey` was persisted cannot be scanned until re-imported.
+   */
+  const scanImportedKey = useCallback(
+    async (id: string): Promise<{ found: number; scanned: number } | null> => {
+      const key = importedKeys.find((k) => k.id === id)
+      if (!key) {
+        setError("Imported key not found")
+        return null
+      }
+      if (!key.spendingPublicKey) {
+        setError(
+          "This key was imported before view-only scanning was supported. Re-import it to scan."
+        )
+        return null
+      }
+
+      try {
+        const network = useSettingsStore.getState().network
+        const connection = new Connection(
+          network === "mainnet-beta"
+            ? "https://api.mainnet-beta.solana.com"
+            : "https://api.devnet.solana.com",
+          { commitment: "confirmed" }
+        )
+
+        const records = await fetchAllTransferRecords(connection)
+        const owned = scanRecordsForOwner(
+          records,
+          hexToBytes(key.viewingPrivateKey),
+          hexToBytes(key.spendingPublicKey)
+        )
+
+        await updateImportedKey(id, {
+          lastScannedAt: Date.now(),
+          paymentsFound: owned.length,
+        })
+
+        return { found: owned.length, scanned: records.length }
+      } catch (err) {
+        console.error("Failed to scan imported viewing key:", err)
+        setError("Failed to scan. Check your network connection and try again.")
+        return null
+      }
+    },
+    [importedKeys, updateImportedKey]
   )
 
   // ============================================================================
@@ -440,6 +521,7 @@ export function useViewingKeys(): UseViewingKeysReturn {
       importViewingKey,
       removeImportedKey,
       updateImportedKey,
+      scanImportedKey,
       getActiveDisclosures,
       hasViewingKey,
     }),
@@ -456,6 +538,7 @@ export function useViewingKeys(): UseViewingKeysReturn {
       importViewingKey,
       removeImportedKey,
       updateImportedKey,
+      scanImportedKey,
       getActiveDisclosures,
       hasViewingKey,
     ]

--- a/src/services/recordOwnership.ts
+++ b/src/services/recordOwnership.ts
@@ -47,3 +47,27 @@ export function checkRecordOwnership(
     return false
   }
 }
+
+/**
+ * Filter a batch of transfer records to ALL those owned by the recipient — VIEW-ONLY.
+ *
+ * Ownership is independent of claimed status, so this returns claimed payments too — the
+ * full history a compliance auditor monitoring an imported viewing key expects. Callers
+ * that only want pending payments should additionally filter on `record.claimed`.
+ * Uses the canonical view-only {@link checkRecordOwnership}, so it needs the viewing
+ * PRIVATE key + spending PUBLIC key only.
+ *
+ * @param records - parsed on-chain transfer records
+ * @param viewingPrivateKey - recipient viewing private key (raw 32-byte scalar seed)
+ * @param spendingPublicKey - recipient spending public key (raw 32-byte ed25519 point)
+ * @returns every record owned by this recipient (claimed or not)
+ */
+export function scanRecordsForOwner(
+  records: TransferRecordData[],
+  viewingPrivateKey: Uint8Array,
+  spendingPublicKey: Uint8Array
+): TransferRecordData[] {
+  return records.filter((record) =>
+    checkRecordOwnership(record, viewingPrivateKey, spendingPublicKey)
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -276,6 +276,13 @@ export interface ImportedViewingKey {
   label: string
   viewingPublicKey: string
   viewingPrivateKey: string
+  /**
+   * Owner's spending public key, carried from the ViewingKeyExport. Required for canonical
+   * view-only scanning (detection needs viewing-private + spending-public). Optional only
+   * for back-compat with keys imported before this field existed — those cannot be scanned
+   * until re-imported.
+   */
+  spendingPublicKey?: string
   ownerAddress?: string
   chain: ChainType
   importedAt: number

--- a/tests/hooks/useViewingKeys.test.ts
+++ b/tests/hooks/useViewingKeys.test.ts
@@ -5,6 +5,41 @@
  */
 
 import { describe, it, expect } from "vitest"
+import { buildImportedViewingKey } from "@/hooks/useViewingKeys"
+import type { ViewingKeyExport } from "@/types"
+
+describe("buildImportedViewingKey (#86: persists spendingPublicKey)", () => {
+  const exportData: ViewingKeyExport = {
+    version: 1,
+    chain: "solana",
+    viewingPublicKey: "0xvpub",
+    viewingPrivateKey: "0xvpriv",
+    spendingPublicKey: "0xspub",
+    exportedAt: 0,
+  }
+
+  it("carries spendingPublicKey from the export into the imported key", () => {
+    const imported = buildImportedViewingKey(exportData, { label: "Auditor" }, "vk_test", 123)
+    expect(imported.spendingPublicKey).toBe("0xspub")
+    expect(imported.viewingPrivateKey).toBe("0xvpriv")
+    expect(imported.viewingPublicKey).toBe("0xvpub")
+    expect(imported.label).toBe("Auditor")
+    expect(imported.chain).toBe("solana")
+    expect(imported.id).toBe("vk_test")
+    expect(imported.importedAt).toBe(123)
+    expect(imported.paymentsFound).toBe(0)
+  })
+
+  it("carries ownerAddress when provided", () => {
+    const imported = buildImportedViewingKey(
+      exportData,
+      { label: "X", ownerAddress: "alice.sol" },
+      "id",
+      0
+    )
+    expect(imported.ownerAddress).toBe("alice.sol")
+  })
+})
 
 // ============================================================================
 // Type Definitions (mirror from useViewingKeys.ts)

--- a/tests/services/recordOwnership.test.ts
+++ b/tests/services/recordOwnership.test.ts
@@ -17,7 +17,7 @@
 import { describe, it, expect } from "vitest"
 import { PublicKey } from "@solana/web3.js"
 import { ed25519 } from "@noble/curves/ed25519"
-import { checkRecordOwnership } from "@/services/recordOwnership"
+import { checkRecordOwnership, scanRecordsForOwner } from "@/services/recordOwnership"
 import {
   generateStealthAddress,
   bytesToHex,
@@ -103,5 +103,48 @@ describe("checkRecordOwnership (canonical view-only)", () => {
     expect(
       checkRecordOwnership(record, VIEWING_SEED, ed25519.getPublicKey(SPENDING_SEED))
     ).toBe(false)
+  })
+})
+
+describe("scanRecordsForOwner (view-only filter)", () => {
+  it("returns all records owned by the key, including claimed (auditor history)", async () => {
+    const mine = await generateStealthAddress(meta())
+    const mineRecord = recordFor(mine.stealthAddress)
+
+    // A record for a different recipient (different spending/viewing keys).
+    const otherMeta = {
+      chain: "solana",
+      spendingKey: `0x${bytesToHex(ed25519.getPublicKey(new Uint8Array(32).fill(0x55)))}`,
+      viewingKey: `0x${bytesToHex(ed25519.getPublicKey(new Uint8Array(32).fill(0x66)))}`,
+    }
+    const theirsRecord = recordFor((await generateStealthAddress(otherMeta)).stealthAddress)
+
+    // A claimed record that is still ours — ownership is independent of claimed status.
+    const claimedMine = recordFor((await generateStealthAddress(meta())).stealthAddress)
+    claimedMine.claimed = true
+
+    const owned = scanRecordsForOwner(
+      [mineRecord, theirsRecord, claimedMine],
+      VIEWING_SEED,
+      ed25519.getPublicKey(SPENDING_SEED)
+    )
+
+    expect(owned).toHaveLength(2)
+    expect(owned).toContain(mineRecord)
+    expect(owned).toContain(claimedMine)
+    expect(owned).not.toContain(theirsRecord)
+  })
+
+  it("returns an empty array when nothing matches", async () => {
+    const { stealthAddress } = await generateStealthAddress(meta())
+    const record = recordFor(stealthAddress)
+
+    const owned = scanRecordsForOwner(
+      [record],
+      WRONG_VIEWING_SEED,
+      ed25519.getPublicKey(SPENDING_SEED)
+    )
+
+    expect(owned).toEqual([])
   })
 })


### PR DESCRIPTION
**Stacked on #88** (`fix/background-scan-canonical`) — it builds on the `checkRecordOwnership` / `checkStealthOwnership` view-only primitives from that PR. GitHub will retarget this to `main` once #88 merges.

## Summary
Fixes #86. An imported viewing key dropped the owner's **spending public key**, so canonical view-only scanning (which needs viewing-private + spending-public) was impossible — the scan UI showed a "not yet available" disclaimer. This persists the spending public key and wires up a real view-only scan.

## Changes
- **`ImportedViewingKey.spendingPublicKey`** — now carried from the `ViewingKeyExport` on import. Extracted the mapping into a pure, tested `buildImportedViewingKey`. (Optional on the type for back-compat: keys imported before this prompt a re-import rather than failing silently.)
- **`scanRecordsForOwner`** (in the #85 `recordOwnership` module) — view-only filter of transfer records by viewing-private + spending-public, returning the **full owned history** (claimed payments included — an auditor wants the complete picture).
- **`useViewingKeys.scanImportedKey(id)`** — fetches transfer records and scans an imported key view-only, updating `lastScannedAt` / `paymentsFound`.
- **Viewing-keys screen** — `handleScanImported` now runs the scan (scanning state on the row + a result toast); the disclaimer is gone.

View-only throughout: detection uses the imported viewing private key + the owner's spending public key — never a spending private key.

## Test plan
- `pnpm typecheck` ✓
- Full suite ✓ — **1447 passed** (+4: `scanRecordsForOwner` ownership/empty cases; `buildImportedViewingKey` persists spendingPublicKey + ownerAddress).

Closes #86
Relates to sip-protocol/sip-protocol#1099.