### PR TITLE
fix(scan): background payment amount from RPC balance (view-only) — #87

### DIFF
--- a/src/services/backgroundScan.ts
+++ b/src/services/backgroundScan.ts
@@ -27,7 +27,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage"
 import { fetchAllTransferRecords } from "@/lib/anchor/client"
 import { bytesToHex } from "@/lib/stealth"
 import { checkRecordOwnership } from "./recordOwnership"
-import { decryptAmount, deriveSharedSecret } from "@/lib/anchor/crypto"
+import { resolveRecordAmountSol } from "./recordAmount"
 import { getRpcClient, type RpcConfig } from "@/lib/rpc"
 import { getRpcApiKey } from "@/lib/config"
 import type { StealthKeysStorage } from "@/types"
@@ -351,18 +351,14 @@ async function performBackgroundScan(): Promise<BackgroundFetch.BackgroundFetchR
         const isOwned = checkRecordOwnership(record, viewingPrivateKey, spendingPublicKey)
 
         if (isOwned) {
-          // Decrypt amount
-          let amount = 0
-          try {
-            // Derive shared secret for decryption
-            const sharedSecret = deriveSharedSecret(viewingPrivateKey, record.ephemeralPubkey)
-            const decrypted = decryptAmount(record.encryptedAmount, sharedSecret)
-            amount = Number(decrypted) / 1e9 // Convert lamports to SOL
-          } catch {
-            // Decryption failed, use a placeholder
-            logger.warn("[BackgroundScan] Failed to decrypt amount")
-            amount = 0
-          }
+          // View-only: the amount is spending-keyed and can't be decrypted with the viewing
+          // key, so read it from the stealth recipient's on-chain SOL balance — mirroring the
+          // foreground useScanPayments fallback. A view-only auditor detects the payment but
+          // reads its value from chain, not by decryption. See #87.
+          const amount = await resolveRecordAmountSol(
+            record.stealthRecipient,
+            (recipient) => connection.getBalance(recipient)
+          )
 
           foundCount++
           totalAmount += amount

--- a/src/services/recordAmount.ts
+++ b/src/services/recordAmount.ts
@@ -1,0 +1,32 @@
+/**
+ * Background-scan amount resolution — view-only RPC balance fallback (#87)
+ *
+ * A view-only auditor can DETECT a stealth payment (canonical EIP-5564) but cannot DECRYPT
+ * its amount: amount encryption is keyed to the SPENDING key, and the background scanner only
+ * holds the spending PUBLIC key. So — mirroring the foreground `useScanPayments` fallback —
+ * the amount is read from the on-chain SOL balance of the one-time stealth recipient address.
+ *
+ * Kept separate from src/services/backgroundScan.ts (which loads expo-task-manager /
+ * -background-fetch / -notifications at import) so it stays unit-testable without native mocks.
+ */
+
+import { LAMPORTS_PER_SOL, type PublicKey } from "@solana/web3.js"
+
+/**
+ * Resolve a stealth payment's SOL amount from the recipient's on-chain balance.
+ *
+ * @param stealthRecipient - the one-time stealth address that received the payment
+ * @param getBalance - lamport-balance fetcher (e.g. `connection.getBalance`)
+ * @returns the balance in SOL, or 0 if empty or the fetch fails (never throws)
+ */
+export async function resolveRecordAmountSol(
+  stealthRecipient: PublicKey,
+  getBalance: (recipient: PublicKey) => Promise<number>
+): Promise<number> {
+  try {
+    const lamports = await getBalance(stealthRecipient)
+    return lamports > 0 ? lamports / LAMPORTS_PER_SOL : 0
+  } catch {
+    return 0
+  }
+}

--- a/tests/services/recordAmount.test.ts
+++ b/tests/services/recordAmount.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Background-scan amount resolution — view-only RPC balance fallback
+ *
+ * Regression test for sip-protocol/sip-mobile#87: the background scanner previously decrypted
+ * the amount with the VIEWING key (the amount is spending-keyed) and could never succeed in
+ * view-only mode, so every notification reported 0 SOL. A view-only auditor can DETECT a
+ * payment but not DECRYPT its amount, so the correct source is the on-chain balance of the
+ * stealth recipient — mirroring the foreground `useScanPayments` RPC fallback.
+ * `resolveRecordAmountSol` fetches that balance and converts lamports → SOL.
+ *
+ * Decoupled from src/services/backgroundScan.ts (which loads expo-task-manager / -background-
+ * fetch / -notifications at import) so it stays unit-testable without native mocks.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { PublicKey } from "@solana/web3.js"
+import { resolveRecordAmountSol } from "@/services/recordAmount"
+
+const RECIPIENT = new PublicKey("So11111111111111111111111111111111111111112")
+
+describe("resolveRecordAmountSol", () => {
+  it("converts the stealth recipient's on-chain lamport balance to SOL", async () => {
+    const getBalance = vi.fn().mockResolvedValue(2_500_000_000) // 2.5 SOL in lamports
+    const amount = await resolveRecordAmountSol(RECIPIENT, getBalance)
+    expect(amount).toBe(2.5)
+  })
+
+  it("queries the balance of the stealth recipient (view-only, no decryption)", async () => {
+    const getBalance = vi.fn().mockResolvedValue(1_000_000_000)
+    await resolveRecordAmountSol(RECIPIENT, getBalance)
+    expect(getBalance).toHaveBeenCalledTimes(1)
+    expect(getBalance).toHaveBeenCalledWith(RECIPIENT)
+  })
+
+  it("returns 0 when the recipient has no balance", async () => {
+    const getBalance = vi.fn().mockResolvedValue(0)
+    expect(await resolveRecordAmountSol(RECIPIENT, getBalance)).toBe(0)
+  })
+
+  it("returns 0 (does not throw) when the balance fetch fails", async () => {
+    const getBalance = vi.fn().mockRejectedValue(new Error("RPC unavailable"))
+    await expect(resolveRecordAmountSol(RECIPIENT, getBalance)).resolves.toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

`performBackgroundScan` (`src/services/backgroundScan.ts`) reported **0 SOL** for every background payment notification. It decrypted the amount with `deriveSharedSecret(viewingPrivateKey, …)` + `decryptAmount`, but:

1. **Wrong key** — amount encryption is keyed to the **spending** key (the send path uses `deriveSharedSecret(ephemeralPrivateKey, recipientSpendingKey)`).
2. **View-only** — the background scanner only holds the spending **public** key, so it fundamentally cannot run the spending-keyed ECDH.

It also fed the un-sliced 33-byte ephemeral key into the derivation. Net: decrypt always threw → `amount = 0`.

## Fix

A view-only auditor can **detect** a payment but not **decrypt** its amount — so the correct source is the on-chain balance of the one-time stealth recipient. This mirrors the foreground `useScanPayments` RPC fallback (`connection.getBalance(record.stealthRecipient)`).

The resolution is extracted into a new dep-light `src/services/recordAmount.ts` (`resolveRecordAmountSol`) so it's unit-testable — `backgroundScan.ts` loads `expo-task-manager`/`-background-fetch`/`-notifications` at import, the same reason `recordOwnership.ts` was split out in #85.

## Tests

`tests/services/recordAmount.test.ts` — 4 tests, TDD red→green:
- lamports → SOL conversion
- queries the stealth recipient (view-only, no decryption)
- zero balance → 0
- fetch failure → 0 (does not throw)

Full suite: **1451 pass** (+4), `tsc --noEmit` clean.

## Out of scope

SPL-token amounts in the background path (the old code didn't handle them either) — a follow-up can mirror the foreground ATA balance path.

Closes #87
