### PR TITLE
chore: add Dependabot config (npm, github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # npm — app root + publishing tooling (each has its own lockfile)
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/publishing"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
## What
Adds a Dependabot config — this repo had none.

Ecosystems now watched (weekly, Mondays):
- **npm** `/` and `/publishing` (each has its own lockfile)
- **github-actions** `/`

## Why
Org-wide Dependabot audit (2026-06-18) found `sip-mobile` — an actively shipping app — had no dependency monitoring. Minor/patch grouped.